### PR TITLE
Document the staging and production release of the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ synchronisation and much more.
 1. [Deploy `feature_branch.<sha>`](https://ci.service.dsd.io/job/DEPLOY-fala/build?delay=0sec).
     * `ENVIRONMENT` is the target environment, select "staging".
     * `DEPLOY_BRANCH` is the [deploy repo's](https://github.com/ministryofjustice/fala-deploy) default branch name, usually `master`.
-    * `VERSION` is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (`github-config>.<843dcc7` for the above example).
+    * `VERSION` is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (`github-config.843dcc7` for the above example).
 
 
 ### Releasing to production

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ synchronisation and much more.
     ```
 1. [Deploy `feature_branch.<sha>`](https://ci.service.dsd.io/job/DEPLOY-fala/build?delay=0sec).
     * `ENVIRONMENT` is the target environment, select "staging".
-    * `DEPLOY_BRANCH` is the branch that needs to be released (`github-config` in the above example).
-    * `VERSION` is either `latest` for the last successful build on that branch, or a specific 7-character prefix of the Git SHA (`843dcc7` in the above example).
+    * `DEPLOY_BRANCH` is the [deploy repo's](https://github.com/ministryofjustice/fala-deploy) default branch name, usually `master`.
+    * `VERSION` is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (`github-config>.<843dcc7` for the above example).
 
 
 ### Releasing to production

--- a/README.md
+++ b/README.md
@@ -49,3 +49,33 @@ gulp serve
 Serve task will create a proxy server on port 3000 that goes via Django’s server on port 8000 enhancing it with
 additional features provided by [Browsersync](http://www.browsersync.io/), such as CSS/JS reload, interaction
 synchronisation and much more.
+
+## Releasing
+
+### Releasing to non-production
+
+> Currently, `staging` is the only non-production environment.
+
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala) for the feature branch.
+1. Copy the `feature_branch.<sha>` reference from the `build` job's "Push Docker image" step. Eg:
+    ```
+    Pushing tag for rev [3e1a4ef9ecf6] on {https://registry.service.dsd.io/v1/repositories/fala/tags/github-config.843dcc7}
+    ```
+1. [Deploy `feature_branch.<sha>`](https://ci.service.dsd.io/job/DEPLOY-fala/build?delay=0sec).
+    * `ENVIRONMENT` is the target environment, select "staging".
+    * `DEPLOY_BRANCH` is the branch that needs to be released (`github-config` in the above example).
+    * `VERSION` is either `latest` for the last successful build on that branch, or a specific 7-character prefix of the Git SHA (`843dcc7` in the above example).
+
+
+### Releasing to production
+
+1. Please make sure you tested on a non-production environment before merging.
+1. Merge your feature branch pull request to `master`.
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala/tree/master) for the `master` branch.
+1. Copy the `master.<sha>` reference from the `build` job's "Push Docker image" step. Eg:
+    ```
+    Pushing tag for rev [ec16b48c493d] on {https://registry.service.dsd.io/v1/repositories/fala/tags/master.2d889b5}
+    ```
+1. [Deploy `master.<sha>` to **prod**uction](https://ci.service.dsd.io/job/DEPLOY-fala/build?delay=0sec).
+
+:tada: :shipit:


### PR DESCRIPTION
## What does this pull request do?

Documents the release process for this application for both non-production and production releases.

🔎 Nicer link to the new section: https://github.com/ministryofjustice/fala/blob/instructions-for-release/README.md#releasing

![fala-release-process](https://user-images.githubusercontent.com/89347/44796961-0618a780-aba6-11e8-9c2b-5bab2e900343.png)

## Any other changes that would benefit highlighting?

We will switch the default branch on this repository from `develop` to `master` once this is merged.