### PR TITLE
LGA-304 Run FALA on a staging Kubernetes namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,33 +4,40 @@ jobs:
     docker:
       - image: docker:17.03-git
     environment:
-      DOCKER_REGISTRY: "registry.service.dsd.io"
-      DOCKER_IMAGE: "fala"
+      DSD_DOCKER_REGISTRY: "registry.service.dsd.io"
+      DSD_DOCKER_IMAGE: "fala"
+      ECR_DOCKER_REGISTRY: "926803513772.dkr.ecr.eu-west-1.amazonaws.com"
+      ECR_DOCKER_IMAGE: "laa-get-access/laa-fala"
     steps:
       - checkout
       - setup_remote_docker:
           version: 17.03.0-ce
           docker_layer_caching: true
       - run:
-          name: Login to container registry
+          name: Login to the DSD Docker registry
           command: |
-            docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD --email "${DOCKER_USERNAME}@digital.justice.gov.uk" $DOCKER_REGISTRY
+            docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD --email "${DOCKER_USERNAME}@digital.justice.gov.uk" $DSD_DOCKER_REGISTRY
+      - run:
+          name: Login to the ECR Docker registry
+          command: |
+            apk add --no-cache --no-progress py2-pip
+            pip install awscli
+            ecr_login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+            ${ecr_login}
       - run:
           name: Build Docker image
           command: |
-            docker build --tag $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 .
-            docker tag $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.$(git rev-parse --short=7 $CIRCLE_SHA1)
-            docker tag $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.latest
+            docker build --tag application:$CIRCLE_SHA1 \
+              --label build.git.sha=$CIRCLE_SHA1 \
+              --label build.git.branch=$CIRCLE_BRANCH \
+              --label build.url=$CIRCLE_BUILD_URL \
+              .
       - run:
           name: Validate Python version
-          command: |
-            docker run --rm --tty --interactive $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 python --version | grep "3.4"
+          command: docker run --rm --tty --interactive application:$CIRCLE_SHA1 python --version | grep "3.4"
       - run:
-          name: Push Docker image
-          command: |
-            docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1
-            docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.$(git rev-parse --short=7 $CIRCLE_SHA1)
-            docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.latest
+          name: Tag and push Docker images
+          command: .circleci/tag_and_push_docker_image application:$CIRCLE_SHA1
 
   test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,15 @@
 version: 2
+
+references:
+  container_config: &container_config
+    docker:
+      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+        environment:
+          ECR_DOCKER_REGISTRY: "926803513772.dkr.ecr.eu-west-1.amazonaws.com"
+          ECR_DOCKER_IMAGE: "laa-get-access/laa-fala"
+          GITHUB_TEAM_NAME_SLUG: laa-get-access
+          APPLICATION_DEPLOY_NAME: laa-fala
+
 jobs:
   build:
     docker:
@@ -69,11 +80,34 @@ jobs:
             source env/bin/activate
             python manage.py test
 
+  staging_deploy:
+    <<: *container_config
+    steps:
+      - checkout
+      - run:
+          name: Initialise Kubernetes staging context
+          command: |
+            setup-kube-auth
+            kubectl config use-context staging
+      - deploy:
+          name: Deploy fala to staging
+          command: .circleci/deploy_to_kubernetes staging
+      - deploy:
+          name: Notify Slack channel
+          command: .circleci/notify_slack_channel staging
+
 workflows:
   version: 2
-  build_and_test:
+  build_test_and_deploy:
     jobs:
       - test
       - build:
           requires:
             - test
+      - staging_deploy_approval:
+          type: approval
+          requires:
+            - build
+      - staging_deploy:
+          requires:
+            - staging_deploy_approval

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+safe_git_branch=${CIRCLE_BRANCH//\//-}
+short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
+deploy_image_and_tag="$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
+ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$deploy_image_and_tag"

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -1,0 +1,28 @@
+#!/bin/sh -eu
+
+ROOT=$(dirname "$0")
+NAMESPACE="$1"
+NAMESPACE_DIR="$ROOT/../kubernetes_deploy/$NAMESPACE"
+
+if ! [ $NAMESPACE ] ; then
+
+  echo "usage: deploy_to_kubernetes namespace\n"
+  echo "namespace is a directory in ../kubernetes_deploy/ directory"
+  exit 1;
+fi
+
+if ! [ -d $NAMESPACE_DIR ] ; then
+  echo "$NAMESPACE_DIR not found"
+  exit 1;
+fi
+
+source "$ROOT/define_build_environment_variables"
+
+echo "Deploying $ECR_DEPLOY_IMAGE to $NAMESPACE..."
+
+kubectl set image --filename="$NAMESPACE_DIR/deployment.yml" --local --output=yaml \
+  app="$ECR_DEPLOY_IMAGE" | \
+  kubectl apply \
+    --filename=/dev/stdin \
+    --filename="$NAMESPACE_DIR/service.yml" \
+    --filename="$NAMESPACE_DIR/ingress.yml"

--- a/.circleci/notify_slack_channel
+++ b/.circleci/notify_slack_channel
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+
+source $(dirname "$0")/define_build_environment_variables
+environment="$1"
+
+cat <<END > payload.json
+{
+  "text": ":tada: Deployed \`$deploy_image_and_tag\` to *$environment*.",
+  "attachments": [
+    {
+      "fallback": "<$CIRCLE_BUILD_URL|View build>",
+      "actions": [{"type": "button", "text": "View build", "url": "$CIRCLE_BUILD_URL"}]
+    }
+  ]
+}
+END
+
+curl --request POST --data @payload.json --header "Content-Type: application/json" $SLACK_WEBHOOK_URL

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -1,0 +1,21 @@
+#!/bin/sh -e
+
+source $(dirname "$0")/define_build_environment_variables
+built_tag="$1"
+
+function tag_and_push() {
+  tag="$1"
+  echo
+  echo "Tagging and pushing $tag..."
+  docker tag $built_tag $tag
+  docker push $tag
+}
+
+if [ "$CIRCLE_BRANCH" == "master" ]; then
+  tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$CIRCLE_SHA1"
+  tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$CIRCLE_SHA1"
+  tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.$short_sha"
+fi
+tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
+tag_and_push "$ECR_DEPLOY_IMAGE"
+tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,28 +8,23 @@ LABEL summary="Find A Legal Adviser" \
 RUN locale-gen "en_US.UTF-8"
 ENV LC_CTYPE=en_US.UTF-8
 
-# Install Node.js, npm, gulp
+# Install python and build dependencies
 RUN apt-get update && \
-    apt-get install -y \
-      build-essential \
-      curl \
-      git \
-      python-minimal && \
-    curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash && \
-    apt-get install -y nodejs && \
-    apt-get clean && \
-    npm install --global npm@5.6.0 && \
-    npm install --global gulp
+    apt-get -y --force-yes install \
+        build-essential \
+        curl \
+        git \
+        libpcre3 \
+        libpcre3-dev \
+        python-minimal \
+        python3-all \
+        python3-all-dev \
+        python3-pip && \
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
-# Install Python3
-RUN apt-get update && \
-    apt-get install -y \
-      libpcre3 libpcre3-dev \
-      python3-all python3-all-dev \
-      python3-pip \
-      && \
-    apt-get clean && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+# Install NodeJS
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get -y --force-yes install nodejs
 
 ENV HOME /home/app
 ENV APP_HOME /home/app
@@ -45,7 +40,7 @@ RUN npm install
 
 COPY . .
 
-RUN gulp --production && \
+RUN ./node_modules/.bin/gulp build --production && \
     ./manage.py collectstatic --noinput
 
 EXPOSE 8000

--- a/conf/uwsgi.ini
+++ b/conf/uwsgi.ini
@@ -8,4 +8,6 @@ max-requests=5000
 env=DJANGO_SETTINGS_MODULE=fala.settings
 processes=2
 harakiri=30
+logger-req=stdio
+logformat={"process_name": "uwsgi", "timestamp_msec": %(tmsecs), "method": "%(method)", "uri": "%(uri)", "proto": "%(proto)", "status": %(status), "referer": "%(referer)", "user_agent": "%(uagent)", "remote_addr": "%(addr)", "http_host": "%(host)", "pid": %(pid), "worker_id": %(wid), "core": %(core), "async_switches": %(switches), "io_errors": %(ioerr), "rq_size": %(cl), "rs_time_ms": %(msecs), "rs_size": %(size), "rs_header_size": %(hsize), "rs_header_count": %(headers)}
 post-buffering=1

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -13,7 +13,7 @@ sys.path.insert(0, root('apps'))
 
 DEBUG = os.environ.get('DEBUG', False)
 DEBUG = DEBUG == 'True' or DEBUG is True
-DEBUG_STATIC = False
+DEBUG_STATIC = os.environ.get('DEBUG_STATIC', False)
 
 ADMINS = ()
 

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -22,8 +22,9 @@ MANAGERS = ADMINS
 DATABASES = {}
 
 ALLOWED_HOSTS = [
+    '.laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io',
     '.fala.dsd.io',
-    '.find-legal-advice.justice.gov.uk',
+    '.find-legal-advice.justice.gov.uk'
 ]
 
 LANGUAGE_CODE = 'en-gb'

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: laa-fala
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: laa-fala-app
+  template:
+    metadata:
+      labels:
+        app: laa-fala-app
+    spec:
+      containers:
+      - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala:master
+        name: app
+        ports:
+        - containerPort: 80
+          name: http

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -18,3 +18,6 @@ spec:
         ports:
         - containerPort: 80
           name: http
+        env:
+        - name: LAALAA_API_HOST
+          value: https://staging.laalaa.dsd.io

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -21,3 +21,5 @@ spec:
         env:
         - name: LAALAA_API_HOST
           value: https://staging.laalaa.dsd.io
+        - name: DEBUG_STATIC
+          value: "True"

--- a/kubernetes_deploy/staging/ingress.yml
+++ b/kubernetes_deploy/staging/ingress.yml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: laa-fala
+  namespace: laa-fala-staging
+spec:
+  rules:
+  - host: laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: laa-fala
+          servicePort: 80

--- a/kubernetes_deploy/staging/service.yml
+++ b/kubernetes_deploy/staging/service.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: laa-fala
+  namespace: laa-fala-staging
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 8000
+  selector:
+    app: laa-fala-app

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "browser-sync": "^2.18.8",
     "gulp": "^3.8.11",
     "gulp-concat": "~2.6",
-    "gulp-sass": "^2.0.4",
+    "gulp-sass": "^4.0.1",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.6",
     "merge-stream": "^1.0.0",


### PR DESCRIPTION
## What does this pull request do?

This pull request does the following:

- Configures the Docker image built in Circle CI build job to be pushed to AWS ECR
- Configures Kubernetes staging environment
- Deploy build to Kubernetes staging environment on successful build
- Notify Slack channel of successful deployment
- Optimise the Dockerfile
- Upgrade `node-sass`

## Any other changes that would benefit highlighting?

For now, I've copied the helper Circle CI scripts from `cla_public`. The plan is to make these scripts, and others, available in a convenience Circle CI image after things have settled down a bit.

The current production instance, hosted via Template Deploy, the static assets are served from an S3 bucket. See https://github.com/ministryofjustice/fala/pull/11#issuecomment-429450104 for more info. Nginx also forwards requests received on port `80` to the python application. `nginx` will be set up in a separate pull request.