### PR TITLE
Configure Legal Adviser API for staging

### DIFF
--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -18,3 +18,6 @@ spec:
         ports:
         - containerPort: 80
           name: http
+        env:
+        - name: LAALAA_API_HOST
+          value: https://staging.laalaa.dsd.io


### PR DESCRIPTION
## What does this pull request do?

Extends the staging Kubernetes configuration to configure the https://github.com/ministryofjustice/laa-legal-adviser-api/ dependency.