### PR TITLE
LGA-316 Configure Kubernetes to use TCP liveness & readiness probe for webapp container

### DIFF
--- a/fala/apps/adviser/middleware.py
+++ b/fala/apps/adviser/middleware.py
@@ -1,0 +1,14 @@
+from django.http import HttpResponse
+
+class PingMiddleware():
+  def process_request(self, request):
+    if request.method == "GET":
+      if request.path == "/ping.json":
+        return self.ping(request)
+    pass
+
+  def ping(self, request):
+    """
+    Returns that the server is alive.
+    """
+    return HttpResponse("OK")

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -84,6 +84,7 @@ TEMPLATES = [
 ]
 
 MIDDLEWARE_CLASSES = (
+    'adviser.middleware.PingMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -15,6 +15,18 @@ spec:
       containers:
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala-webapp:master
         name: webapp
+        readinessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
         ports:
         - containerPort: 8000
           name: http


### PR DESCRIPTION
## What does this pull request do?

This pull requests configures Kubernetes to use liveness and readiness probes to determine the health of the web app container.

>Readiness and liveness probes can be used in parallel for the same container. Using both can ensure that traffic does not reach a container that is not ready for it, and that containers are restarted when they fail.

The kubelet will send the first readiness probe 5 seconds after the container starts. The kubelet will continue to run this check every 10 seconds until its ready. This application starts up quickly - it doesn't need to wait for anything to happen, e.g. load data.

The liveness probe is configured in the same way. If it cannot establish connection on TCP port 8000, Kubernetes will restart the container.

![restart-container-demo-2](https://user-images.githubusercontent.com/89347/47560430-146a1200-d910-11e8-9c38-a0312457e766.gif)

## Any other changes that would benefit highlighting?

Initially, I added a `/ping.json` endpoint, before realising that direct communication to the application isn't possible because communication happens via the uwsgi protocol, so we instead check that this is up and running on TCP port 8000. The `/ping.json` endpoint remains there in case we want to revisit this approach.