### PR TITLE
Enable logstash formatter for console logs

### DIFF
--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -128,40 +128,20 @@ LOGGING = {
             '()': 'logstash_formatter.LogstashFormatter'
         }
     },
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
-        },
-        'require_debug_true': {
-            '()': 'django.utils.log.RequireDebugTrue'
-        }
-    },
     'handlers': {
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'stream': sys.stdout,
+            'formatter': 'logstash'
         }
     },
     'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': True,
+        'root': {
+            'level': 'DEBUG',
+            'handlers': ['console'],
         }
     }
-}
-
-LOGGING['handlers']['console'] = {
-    'level': 'DEBUG',
-    'class': 'logging.StreamHandler',
-    'stream': sys.stdout,
-    'formatter': 'logstash'
-}
-
-LOGGING['loggers'][''] = {
-    'handlers': ['console'],
-    'level': "DEBUG",
 }
 
 # RAVEN SENTRY CONFIG

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -155,7 +155,8 @@ LOGGING = {
 LOGGING['handlers']['console'] = {
     'level': 'DEBUG',
     'class': 'logging.StreamHandler',
-    'stream': sys.stdout
+    'stream': sys.stdout,
+    'formatter': 'logstash'
 }
 
 LOGGING['loggers'][''] = {

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -33,6 +33,11 @@ spec:
         env:
         - name: LAALAA_API_HOST
           value: https://staging.laalaa.dsd.io
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: dsn
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala-nginx:master
         name: nginx
         readinessProbe:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django==1.8.4
-raven==5.7.2
+raven==6.9.0
 uwsgi==2.0.17
 requests==2.7.0
 django_jinja==1.4.1


### PR DESCRIPTION
## What does this pull request do?

This pull request configures the console handler to use the `logstash` formatter.

## Any other changes that would benefit highlighting?

See the [comment I left in Jira](https://dsdmoj.atlassian.net/browse/LGA-299?focusedCommentId=60884&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-60884).

### Remove mail_admins handler
As describe in the Jira comment, the `mail_admins` handler has been removed.

### Update Sentry's Raven client

This pull request originally attempted to replace the Raven client with [Sentry's Unified Python SDK](https://docs.sentry.io/quickstart?platform=python). However, there was trouble getting it working with correctly with uWSGI. Instead of tackling this in this PR, the upgrade from Raven to Sentry's Unified Python SDK will be deferred and can be done across all of our applications at the same time.

### Configure Sentry for staging environment
Sentry now has project set up for FALA staging. See https://sentry.service.dsd.io/mojds/staging-fala/. I tested it by forcing an error - an event was triggered and can be seen in Sentry.

<img width="730" alt="screen shot 2018-11-02 at 10 22 21" src="https://user-images.githubusercontent.com/89347/47909958-45ef5a00-de89-11e8-9177-5837ae6ce89f.png">

The error was forced by changing the `template_name` in `fala/adviser/views.py` to something that did not exist, then viewing the related page in the browser. The change was made directly in a running a container.
