### PR TITLE
Configure Kubernetes production deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,10 @@ workflows:
           type: approval
           requires:
             - staging_deploy
+          filters:
+            branches:
+              only:
+                - master
       - production_deploy:
           requires:
             - production_deploy_approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,5 @@
 version: 2
 
-references:
-  container_config: &container_config
-    docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
-        environment:
-          GITHUB_TEAM_NAME_SLUG: laa-get-access
-          APPLICATION_DEPLOY_NAME: laa-fala-webapp
-
 jobs:
   build_web:
     docker:
@@ -107,7 +99,8 @@ jobs:
             python manage.py test
 
   staging_deploy:
-    <<: *container_config
+    docker:
+      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
     steps:
       - checkout
       - run:
@@ -122,6 +115,24 @@ jobs:
       - deploy:
           name: Notify Slack channel
           command: .circleci/notify_slack_channel staging
+
+  production_deploy:
+    docker:
+      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+    steps:
+      - checkout
+      - run:
+          name: Initialise Kubernetes production context
+          command: |
+            setup-kube-auth
+            kubectl config use-context production
+      - deploy:
+          name: Deploy fala to production
+          command: |
+            .circleci/deploy_to_kubernetes production ${ECR_DOCKER_REPO_BASE}-webapp ${ECR_DOCKER_REPO_BASE}-nginx 
+      - deploy:
+          name: Notify Slack channel
+          command: .circleci/notify_slack_channel production
 
 workflows:
   version: 2
@@ -142,3 +153,10 @@ workflows:
       - staging_deploy:
           requires:
             - staging_deploy_approval
+      - production_deploy_approval:
+          type: approval
+          requires:
+            - staging_deploy
+      - production_deploy:
+          requires:
+            - production_deploy_approval

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ and visit http://localhost:8002
 
 ### Releasing to non-production
 
+#### Template Deploy
+
 > Currently, `staging` is the only non-production environment.
 
 1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala) for the feature branch.
@@ -91,8 +93,22 @@ and visit http://localhost:8002
     * `DEPLOY_BRANCH` is the [deploy repo's](https://github.com/ministryofjustice/fala-deploy) default branch name, usually `master`.
     * `VERSION` is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (`github-config.843dcc7` for the above example).
 
+#### Deploy to Kubernetes using Circle CI
+
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala) for the feature branch.
+1. Approve the pending staging deployment on CircleCI.
+    [Watch the how-to video:](https://www.youtube.com/watch?v=9JovuQK-XnA)<br/>
+    [![How to approve staging deployments](https://img.youtube.com/vi/9JovuQK-XnA/1.jpg)](https://www.youtube.com/watch?v=9JovuQK-XnA)
+1. :rotating_light: Unfortunately, our deployment process does not _yet_ fail the build if the deployment fails.
+    To see if the deploy was successful, follow Kubernetes deployments, pods and events for any feedback:
+    ```
+    kubectl --namespace laa-fala-staging get pods,deployments -o wide
+    kubectl --namespace laa-fala-staging get events
+
 
 ### Releasing to production
+
+#### Template Deploy
 
 1. Please make sure you tested on a non-production environment before merging.
 1. Merge your feature branch pull request to `master`.
@@ -102,5 +118,21 @@ and visit http://localhost:8002
     Pushing tag for rev [ec16b48c493d] on {https://registry.service.dsd.io/v1/repositories/fala/tags/master.2d889b5}
     ```
 1. [Deploy `master.<sha>` to **prod**uction](https://ci.service.dsd.io/job/DEPLOY-fala/build?delay=0sec).
+
+#### Deploy to Kubernetes using Circle CI
+
+**Note:** We currently have an offline production environment in Kubernetes. This will not be mapped to the public URL until further tasks have been completed.
+
+1. Please make sure you tested on a non-production environment before merging.
+1. Merge your feature branch pull request to `master`.
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala/tree/master) for the `master` branch.
+1. Approve the pending staging deployment on CircleCI (see 'Releasing to non-production above' video for more info).
+1. Approve the pending production deployment on CircleCI.
+1. :rotating_light: Unfortunately, our deployment process does not _yet_ fail the build if the deployment fails.
+    To see if the deploy was successful, follow Kubernetes deployments, pods and events for any feedback:
+    ```
+    kubectl --namespace laa-fala-production get pods,deployments -o wide
+    kubectl --namespace laa-fala-production get events
+    ```
 
 :tada: :shipit:

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -21,12 +21,8 @@ MANAGERS = ADMINS
 
 DATABASES = {}
 
-ALLOWED_HOSTS = [
-    '.laa-fala-production.apps.cloud-platform-live-0.k8s.integration.dsd.io',
-    '.laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io',
-    '.fala.dsd.io',
-    '.find-legal-advice.justice.gov.uk'
-]
+DEFAULT_ALLOWED_HOSTS = '.fala.dsd.io .find-legal-advice.justice.gov.uk'
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', DEFAULT_ALLOWED_HOSTS).split(' ')
 
 LANGUAGE_CODE = 'en-gb'
 

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -22,6 +22,7 @@ MANAGERS = ADMINS
 DATABASES = {}
 
 ALLOWED_HOSTS = [
+    '.laa-fala-production.apps.cloud-platform-live-0.k8s.integration.dsd.io',
     '.laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io',
     '.fala.dsd.io',
     '.find-legal-advice.justice.gov.uk'

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -32,7 +32,12 @@ spec:
           name: http
         env:
         - name: LAALAA_API_HOST
-          value: https://staging.laalaa.dsd.io
+          value: https://prod.laalaa.dsd.io
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: dsn
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala-nginx:master
         name: nginx
         readinessProbe:

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: laa-fala
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: laa-fala-app

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -1,0 +1,54 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: laa-fala
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: laa-fala-app
+  template:
+    metadata:
+      labels:
+        app: laa-fala-app
+    spec:
+      containers:
+      - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala-webapp:master
+        name: webapp
+        readinessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        ports:
+        - containerPort: 8000
+          name: http
+        env:
+        - name: LAALAA_API_HOST
+          value: https://staging.laalaa.dsd.io
+      - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala-nginx:master
+        name: nginx
+        readinessProbe:
+          httpGet:
+            path: /static/ping.json
+            port: 80
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /static/ping.json
+            port: 80
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        ports:
+        - containerPort: 80
+          name: http

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -31,6 +31,8 @@ spec:
         - containerPort: 8000
           name: http
         env:
+        - name: ALLOWED_HOSTS
+          value: ".laa-fala-production.apps.cloud-platform-live-0.k8s.integration.dsd.io .find-legal-advice.justice.gov.uk"
         - name: LAALAA_API_HOST
           value: https://prod.laalaa.dsd.io
         - name: SENTRY_DSN

--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: laa-fala
+  namespace: laa-fala-production
+spec:
+  rules:
+  - host: laa-fala-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: laa-fala
+          servicePort: 80

--- a/kubernetes_deploy/production/service.yml
+++ b/kubernetes_deploy/production/service.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: laa-fala
+  namespace: laa-fala-production
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 80
+  selector:
+    app: laa-fala-app

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -31,6 +31,8 @@ spec:
         - containerPort: 8000
           name: http
         env:
+        - name: ALLOWED_HOSTS
+          value: .laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
         - name: LAALAA_API_HOST
           value: https://staging.laalaa.dsd.io
         - name: SENTRY_DSN


### PR DESCRIPTION
## What does this pull request do?

This pull request does the following:

- Configures Kubernetes production environment
- Allows deploys to Kubernetes production environment for `master` branch only
- Notify Slack channel of successful deployment to production

## Any other changes that would benefit highlighting?

`ALLOWED_HOSTS` value is now retrieved from the environment, if available. When it's not, default values are used. The defaults are a temporary workaround until we stop using the legacy Template Deploy platform.
