### PR TITLE
LGA-306: Add "Use Kubernetes" documentation and split README into separate files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,138 +1,17 @@
 # Find a Legal Adviser
 
-## Install Python 3 with Virtualenv (OSX)
+This repository holds the code for the "Find a legal aid adviser or family mediator" application. The service helps members of the public in England and Wales to search for a legal adviser or family mediator with a legal aid contract.
 
-```
-brew install python3
-virtualenv -p python3 venv
-source venv/bin/activate
-```
+The website address is https://find-legal-advice.justice.gov.uk/.
 
-## Development
+## Public API
 
-:memo: The application assumes Node.js 8 to be installed.
+The website uses the LAA Legal Adviser API. The code is hosted at https://github.com/ministryofjustice/laa-legal-adviser-api.
 
-Install NPM dependencies (Gulp, Mojular etc.):
+The REST API is https://prod.laalaa.dsd.io/.
 
-```
-npm install
-```
+## Documentation
 
-Install Python depencenies:
-
-```
-pip install -r requirements/base.txt
-```
-
-Create `fala/settings/local.py`:
-```
-cp fala/settings/local.example.py fala/settings/local.py
-```
-
-Run Django server:
-
-```
-python3 ./manage.py runserver
-```
-
-Build assets:
-```
-npm run build
-```
-
-Or run Gulp tasks (default task is `build`):
-
-```
-npm run serve
-```
-
-Serve task will create a proxy server on port 3000 that goes via Django’s server on port 8000 enhancing it with
-additional features provided by [Browsersync](http://www.browsersync.io/), such as CSS/JS reload, interaction
-synchronisation and much more.
-
-### Running Nginx and Django locally
-You must refer to the name of the `webapp` container in `nginx.conf.
-
-Update `nginx.conf`:
-
-```
-upstream webapp {
-    server localhost:8000;
-}
-```
-to:
-```
-upstream webapp {
-    server webapp:8000;
-}
-```
-
-Then run:
-
-```
-docker-compose up
-```
-
-and visit http://localhost:8002
-
-## Releasing
-
-### Releasing to non-production
-
-#### Template Deploy
-
-> Currently, `staging` is the only non-production environment.
-
-1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala) for the feature branch.
-1. Copy the `feature_branch.<sha>` reference from the `build` job's "Push Docker image" step. Eg:
-    ```
-    Pushing tag for rev [3e1a4ef9ecf6] on {https://registry.service.dsd.io/v1/repositories/fala/tags/github-config.843dcc7}
-    ```
-1. [Deploy `feature_branch.<sha>`](https://ci.service.dsd.io/job/DEPLOY-fala/build?delay=0sec).
-    * `ENVIRONMENT` is the target environment, select "staging".
-    * `DEPLOY_BRANCH` is the [deploy repo's](https://github.com/ministryofjustice/fala-deploy) default branch name, usually `master`.
-    * `VERSION` is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (`github-config.843dcc7` for the above example).
-
-#### Deploy to Kubernetes using Circle CI
-
-1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala) for the feature branch.
-1. Approve the pending staging deployment on CircleCI.
-    [Watch the how-to video:](https://www.youtube.com/watch?v=9JovuQK-XnA)<br/>
-    [![How to approve staging deployments](https://img.youtube.com/vi/9JovuQK-XnA/1.jpg)](https://www.youtube.com/watch?v=9JovuQK-XnA)
-1. :rotating_light: Unfortunately, our deployment process does not _yet_ fail the build if the deployment fails.
-    To see if the deploy was successful, follow Kubernetes deployments, pods and events for any feedback:
-    ```
-    kubectl --namespace laa-fala-staging get pods,deployments -o wide
-    kubectl --namespace laa-fala-staging get events
-
-
-### Releasing to production
-
-#### Template Deploy
-
-1. Please make sure you tested on a non-production environment before merging.
-1. Merge your feature branch pull request to `master`.
-1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala/tree/master) for the `master` branch.
-1. Copy the `master.<sha>` reference from the `build` job's "Push Docker image" step. Eg:
-    ```
-    Pushing tag for rev [ec16b48c493d] on {https://registry.service.dsd.io/v1/repositories/fala/tags/master.2d889b5}
-    ```
-1. [Deploy `master.<sha>` to **prod**uction](https://ci.service.dsd.io/job/DEPLOY-fala/build?delay=0sec).
-
-#### Deploy to Kubernetes using Circle CI
-
-**Note:** We currently have an offline production environment in Kubernetes. This will not be mapped to the public URL until further tasks have been completed.
-
-1. Please make sure you tested on a non-production environment before merging.
-1. Merge your feature branch pull request to `master`.
-1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala/tree/master) for the `master` branch.
-1. Approve the pending staging deployment on CircleCI (see 'Releasing to non-production above' video for more info).
-1. Approve the pending production deployment on CircleCI.
-1. :rotating_light: Unfortunately, our deployment process does not _yet_ fail the build if the deployment fails.
-    To see if the deploy was successful, follow Kubernetes deployments, pods and events for any feedback:
-    ```
-    kubectl --namespace laa-fala-production get pods,deployments -o wide
-    kubectl --namespace laa-fala-production get events
-    ```
-
-:tada: :shipit:
+* [Installation](docs/installation.md)
+* [Development](docs/development.md)
+* [Releasing](docs/releasing.md)

--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ The REST API is https://prod.laalaa.dsd.io/.
 
 * [Installation](docs/installation.md)
 * [Development](docs/development.md)
+* [Using Kubernetes](docs/kubernetes.md)
 * [Releasing](docs/releasing.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,11 +8,8 @@ FALA is using [Gulp](http://gulpjs.com/) for build tasks. The following Gulp tas
 - `sass` builds the SCSS and generates source maps
 - `serve` watches the files for changes and reloads the browser using [BrowserSync](http://www.browsersync.io/)
 
-Or run Gulp tasks (default task is `build`):
+:memo: It is also possible to use `npm run build` and `npm run serve` instead of gulp directly.
 
-```
-gulp serve
-```
 
 Serve task will create a proxy server on port 3000 that goes via Django’s server on port 8000 enhancing it with
 additional features provided by [Browsersync](http://www.browsersync.io/), such as CSS/JS reload, interaction

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,13 +10,13 @@ FALA is using [Gulp](http://gulpjs.com/) for build tasks. The following Gulp tas
 
 :memo: It is also possible to use `npm run build` and `npm run serve` instead of gulp directly.
 
-
-Serve task will create a proxy server on port 3000 that goes via Django’s server on port 8000 enhancing it with
+The `serve` task will create a proxy server on port 3000 that goes via Django’s server on port 8000 enhancing it with
 additional features provided by [Browsersync](http://www.browsersync.io/), such as CSS/JS reload, interaction
 synchronisation and much more.
 
 ## Running Nginx and Django locally
-You must refer to the name of the `webapp` container in `nginx.conf.
+
+You must refer to the name of the `webapp` container in `nginx.conf`.
 
 Update `nginx.conf`:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 Assets reside in `fala/assets-src` directory and compiled in `fala/assets` directory upon running build tasks.
 
-FALA is using [Gulp](http://gulpjs.com/) for build tasks. The following Gulp tasks are used in development:
+FALA uses [Gulp](http://gulpjs.com/) for build tasks. The following Gulp tasks are used in development:
 
 - `build` builds and minifies all assets and does all of the following
 - `sass` builds the SCSS and generates source maps
@@ -10,7 +10,7 @@ FALA is using [Gulp](http://gulpjs.com/) for build tasks. The following Gulp tas
 
 :memo: It is also possible to use `npm run build` and `npm run serve` instead of gulp directly.
 
-The `serve` task will create a proxy server on port 3000 that goes via Django’s server on port 8000 enhancing it with
+The `serve` task starts a server on port 3000 proxying Django’s server on port 8000 enhancing it with
 additional features provided by [Browsersync](http://www.browsersync.io/), such as CSS/JS reload, interaction
 synchronisation and much more.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,44 @@
+# Development
+
+Assets reside in `fala/assets-src` directory and compiled in `fala/assets` directory upon running build tasks.
+
+FALA is using [Gulp](http://gulpjs.com/) for build tasks. The following Gulp tasks are used in development:
+
+- `build` builds and minifies all assets and does all of the following
+- `sass` builds the SCSS and generates source maps
+- `serve` watches the files for changes and reloads the browser using [BrowserSync](http://www.browsersync.io/)
+
+Or run Gulp tasks (default task is `build`):
+
+```
+gulp serve
+```
+
+Serve task will create a proxy server on port 3000 that goes via Django’s server on port 8000 enhancing it with
+additional features provided by [Browsersync](http://www.browsersync.io/), such as CSS/JS reload, interaction
+synchronisation and much more.
+
+## Running Nginx and Django locally
+You must refer to the name of the `webapp` container in `nginx.conf.
+
+Update `nginx.conf`:
+
+```
+upstream webapp {
+    server localhost:8000;
+}
+```
+to:
+```
+upstream webapp {
+    server webapp:8000;
+}
+```
+
+Then run:
+
+```
+docker-compose up
+```
+
+and visit http://localhost:8002

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,7 +17,7 @@ Next, create the environment and start it up:
 
 ```
 cd fala
-virtualenv -p python3 venv
+virtualenv -p python3 env
 source env/bin/activate
 
 pip install -r requirements/base.txt
@@ -28,7 +28,7 @@ npm run build
 Create a ``local.py`` settings file from the example file:
 
 ```
-fala/settings/local.example.py fala/settings/local.py
+cp fala/settings/local.example.py fala/settings/local.py
 ```
 
 Next, run the Django server with:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,38 @@
+# Installation
+
+## Dependencies
+
+- [Virtualenv](http://www.virtualenv.org/en/latest/)
+- [Python 3](http://www.python.org/) (Can be installed using `brew install python3`)
+- [nodejs.org](http://nodejs.org/) (v8.12 - can be installed using [nvm](https://github.com/creationix/nvm))
+- [docker](https://www.docker.com/) - Only required for running application from Docker
+
+## Manual Installation
+
+Clone the repository:
+```
+git clone git@github.com:ministryofjustice/fala.git
+```
+Next, create the environment and start it up:
+
+```
+cd fala
+virtualenv -p python3 venv
+source env/bin/activate
+
+pip install -r requirements/base.txt
+npm install
+npm run build
+```
+
+Create a ``local.py`` settings file from the example file:
+
+```
+fala/settings/local.example.py fala/settings/local.py
+```
+
+Next, run the Django server with:
+
+```
+python3 ./manage.py runserver
+```

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,60 @@
+# Using Kubernetes
+
+Read the following if you want to use Kubernetes from your local development environment.
+
+## Setup kubectl
+
+You'll need to install and configure `kubectl` CLI tool to interact with Kubernetes. There are [instructions on kubectl configuration](https://ministryofjustice.github.io/cloud-platform-user-docs/01-getting-started/001-kubectl-config/) in the Cloud Platform User Guide.
+
+## Kubernetes namespaces
+
+
+`fala` has two namespaces (environments):
+
+- [laa-fala-staging](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-staging)
+- [laa-fala-production](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/laa-fala-production)
+
+## Admin role
+
+When you become a member of the GitHub team `laa-get-access`, you'll automatically get the `ClusterRole - admin` role.
+
+>**What is the ClusterRole -admin**
+>Allows admin access, intended to be granted within a namespace using a RoleBinding. If used in a RoleBinding, allows read/write access to most resources in a namespace, including the ability to create roles and rolebindings within the namespace. It does not allow write access to resource quota or to the namespace itself. https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+You can [find out more about roles](https://ministryofjustice.github.io/cloud-platform-user-docs/01-getting-started/002-env-create/#01-rbacyaml) in the Cloud Platform User Guide.
+
+
+## Authenticating with the Docker registry
+Docker images are stored in AWS ECR. To authenticate with the `cla_public` repository, fetch the credentials by typing the following:
+
+```
+kubectl --namespace laa-fala-staging get secrets -o yaml
+```
+
+This command will return the **encoded** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. You can find out more by reading [Authenticating with the repository](https://ministryofjustice.github.io/cloud-platform-user-docs/02-deploying-an-app/001-app-deploy/#authenticating-with-the-repository).
+
+## Deploying to Kubernetes
+
+The standard way of deploying is via CircleCI deploy jobs. See [Deploy to Kubernetes using CircleCI](#deploy-to-kubernetes-using-circleci).
+
+If you need to deploy manually because, for example, CircleCI is offline, follow these steps:
+
+1. Build the Docker image locally. For example:
+    ```
+    docker build -t fala:latest .
+    ```
+1. Tag the build. For example:
+    ```
+    docker tag fala:latest 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala:awesometag
+    ```
+1. Push the docker image. For example:
+    ```
+    docker push 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala:awesometag
+    ```
+1. Deploy changes to Kubernetes by applying changes to the `deployment.yml`. This example takes the `deployment.yml` as input, changes the value of `image` for the container named `app` to `926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala:awesometag`, then pipes the updated yaml to the next command. The `kubectl apply` applies the yaml from stdin:
+    ```
+    kubectl set image --filename="kubernetes_deploy/staging/deployment.yml" --local --output=yaml app="926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala:awesometag" | kubectl apply --filename=/dev/stdin
+    ```
+   A similiar technique is used in [deploy_to_kubernetes](https://github.com/ministryofjustice/fala/blob/master/.circleci/deploy_to_kubernetes) script. Of course, you could simply update the `deployment.yml` file directly and apply the changes.
+   
+   The `.circleci/deploy_to_kubernetes` relies on Circle CI environment variables being present, `CIRCLE_BRANCH` and `CIRCLE_SHA1`, so using the script from your local environment isn't possible yet. The plan is to remove these dependencies from the deploy script.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,59 @@
+# Releasing to non-production
+
+## Template Deploy
+
+> Currently, `staging` is the only non-production environment.
+
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala) for the feature branch.
+1. Copy the `feature_branch.<sha>` reference from the `build` job's "Push Docker image" step. Eg:
+    ```
+    Pushing tag for rev [3e1a4ef9ecf6] on {https://registry.service.dsd.io/v1/repositories/fala/tags/github-config.843dcc7}
+    ```
+1. [Deploy `feature_branch.<sha>`](https://ci.service.dsd.io/job/DEPLOY-fala/build?delay=0sec).
+    * `ENVIRONMENT` is the target environment, select "staging".
+    * `DEPLOY_BRANCH` is the [deploy repo's](https://github.com/ministryofjustice/fala-deploy) default branch name, usually `master`.
+    * `VERSION` is the branch that needs to be released plus a specific 7-character prefix of the Git SHA. (`github-config.843dcc7` for the above example).
+
+## Deploy to Kubernetes using Circle CI
+
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala) for the feature branch.
+1. Approve the pending staging deployment on CircleCI.
+    [Watch the how-to video:](https://www.youtube.com/watch?v=9JovuQK-XnA)<br/>
+    [![How to approve staging deployments](https://img.youtube.com/vi/9JovuQK-XnA/1.jpg)](https://www.youtube.com/watch?v=9JovuQK-XnA)
+1. :rotating_light: Unfortunately, our deployment process does not _yet_ fail the build if the deployment fails.
+    To see if the deploy was successful, follow Kubernetes deployments, pods and events for any feedback:
+    ```
+    kubectl --namespace laa-fala-staging get pods,deployments -o wide
+    kubectl --namespace laa-fala-staging get events
+
+
+# Releasing to production
+
+## Template Deploy
+
+1. Please make sure you tested on a non-production environment before merging.
+1. Merge your feature branch pull request to `master`.
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala/tree/master) for the `master` branch.
+1. Copy the `master.<sha>` reference from the `build` job's "Push Docker image" step. Eg:
+    ```
+    Pushing tag for rev [ec16b48c493d] on {https://registry.service.dsd.io/v1/repositories/fala/tags/master.2d889b5}
+    ```
+1. [Deploy `master.<sha>` to **prod**uction](https://ci.service.dsd.io/job/DEPLOY-fala/build?delay=0sec).
+
+## Deploy to Kubernetes using Circle CI
+
+**Note:** We currently have an offline production environment in Kubernetes. This will not be mapped to the public URL until further tasks have been completed.
+
+1. Please make sure you tested on a non-production environment before merging.
+1. Merge your feature branch pull request to `master`.
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/fala/tree/master) for the `master` branch.
+1. Approve the pending staging deployment on CircleCI (see 'Releasing to non-production above' video for more info).
+1. Approve the pending production deployment on CircleCI.
+1. :rotating_light: Unfortunately, our deployment process does not _yet_ fail the build if the deployment fails.
+    To see if the deploy was successful, follow Kubernetes deployments, pods and events for any feedback:
+    ```
+    kubectl --namespace laa-fala-production get pods,deployments -o wide
+    kubectl --namespace laa-fala-production get events
+    ```
+
+:tada: :shipit:


### PR DESCRIPTION
## What does this pull request do?

This pull request adds a "Using Kubernetes" section to the README. See:

https://github.com/ministryofjustice/fala/blob/docs/README.md

## Any other changes that would benefit highlighting?

It also breaks the README into separate files as it was getting a bit long.