### PR TITLE
Update scripts in package.json to include build and serve scripts and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ python3 ./manage.py runserver
 
 Build assets:
 ```
-gulp build
+npm run build
 ```
 
 Or run Gulp tasks (default task is `build`):
 
 ```
-gulp serve
+npm run serve
 ```
 
 Serve task will create a proxy server on port 3000 that goes via Django’s server on port 8000 enhancing it with

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Find a Legal Adviser",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "gulp build",
+    "serve": "gulp serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
… update documentation in Readme to reflect this

## What does this pull request do?

This pull request updates the documentation for setting up FALA. While using the document I was unable to install the 'Build assets' section using the commands 'gulp build' and 'gulp serve'. Gulp is listed in the package.json but it was unable to be installed without the correct file path. 

This could have been solved by listing the file path directly in the documentation however npm supports the "scripts" property of the package.json file, so by listing it there, npm can generate the correct file path automatically on installation. 


## Any other changes that would benefit highlighting?

On further discussion with Nick, there is also an updated npm that installs npx. npx makes the process even easier for individuals using documentation. By putting $ npx my-tool into the README.md instructions it is possible to just copy-paste one command with out making any other changes. 

[Introducing npx: an npm package runner ](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)