### PR TITLE
Disable feedback page (temporarily)

### DIFF
--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -9,7 +9,7 @@ function tag_and_push() {
   echo
   echo "Tagging and pushing $tag..."
   docker tag $built_tag $tag
-  docker push $tag
+  docker push $tag || docker push $tag || docker push $tag
 }
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,12 @@ RUN pip3 install --user --requirement ./requirements.txt
 
 # Install npm dependencies
 COPY package.json package-lock.json ./
-RUN npm install --production
+RUN npm install
 
 COPY . .
+
+RUN ./node_modules/.bin/gulp build --production && \
+    ./manage.py collectstatic --noinput
 
 EXPOSE 8000
 CMD ["/home/app/docker/run.sh"]

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -42,9 +42,6 @@
   <div class="global-subheader container">
     <div class="subheader-item phase-banner">
       <span class="phase-tag phase-tag-alpha">ALPHA</span>
-      <div class="phase-banner-message">
-        This is a new service – your <a href="/feedback">feedback</a> will help us to improve it.
-      </div>
     </div>
   </div>
 {% endblock %}
@@ -76,7 +73,6 @@
 
 {% block support_links_items %}
   <li><a href="https://www.gov.uk/help/cookies">Cookies</a></li>
-  <li><a href="{{ url('feedback') }}">Feedback</a></li>
   <li><a href="https://www.gov.uk/government/organisations/legal-aid-agency">Legal Aid Agency</a></li>
 {% endblock %}
 

--- a/fala/urls.py
+++ b/fala/urls.py
@@ -3,12 +3,9 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.conf.urls import url
 from adviser.views import AdviserView
-from feedback.views import FeedbackView, FeedbackConfirmationView
 
 urlpatterns = [
     url(r'^$', AdviserView.as_view(), name='adviser'),
-    url(r'^feedback/$', FeedbackView.as_view(), name='feedback'),
-    url(r'^feedback/success$', FeedbackConfirmationView.as_view(), name='feedback_confirmation'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 if settings.DEBUG_STATIC:


### PR DESCRIPTION
## What does this pull request do?

At the moment, we are getting massive spam.
We are taking the feedback page offline until we implement proper spam filters.

## Any other changes that would benefit highlighting?

The `docker push` will be retried 3 times as currently we are facing 504 errors from one of the older Docker registries and the retry is the accepted workaround until we can fully migrate to Kubernetes. (😭)

Reverts the removal of `/home/app/fala/static` folder in commit 564cc51e677a92ba32866ab0ffe3f15794fb59d4 as the folder is still required for template-deploy.