### PR TITLE
Expose uwsgi service on http protocol

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -25,8 +25,12 @@ http {
       }
 
       location / {
-          uwsgi_pass  webapp;
-          include     /etc/nginx/uwsgi_params;
+          proxy_redirect     off;
+          proxy_set_header   X-Real-IP         $HTTP_X_REAL_IP;
+          proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+          proxy_set_header   X-Forwarded-Proto $HTTP_X_FORWARDED_PROTO;
+          proxy_set_header   Host              $host;
+          proxy_pass         http://webapp;
       }
   }
 }

--- a/conf/uwsgi.ini
+++ b/conf/uwsgi.ini
@@ -1,5 +1,5 @@
 [uwsgi]
-socket = :8000
+http=0.0.0.0:8000
 buffer-size=32768
 module=fala.wsgi:application
 master=True


### PR DESCRIPTION
## What does this pull request do?

In the template-deploy world, the application runs in a Docker container but the nginx service is running on the host machine.

We don't know how to reconfigure the nginx server running on template-deploy to use the `uwsgi` protocol currently exposed, so I am taking the route of reverting the configuration to use the `http` protocol.

~~This will most likely **break** the Kubernetes configuration and it will have to be fixed.~~ Kubernetes configuration has also changed to reflect the same configuration.

## Any other thoughts

Related: #22, #14 