### PR TITLE
LGA-47 Redact postcode from GA location before pageview send

### DIFF
--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -81,6 +81,7 @@
   {% if GA_ID %}
     <script>
       ga('create', '{{ GA_ID }}', 'auto');
+      ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));
       ga('send', 'pageview');
     </script>
   {% endif %}


### PR DESCRIPTION
## What does this pull request do?

Explicitly sets postcode redacted location for GA before pageview send

## Any other changes that would benefit highlighting?

Intentionally left blank.
