### PR TITLE
LGA-458 - Review and copy required FALA configuration to Kubernetes

### DIFF
--- a/conf/uwsgi.ini
+++ b/conf/uwsgi.ini
@@ -6,7 +6,6 @@ master=True
 pidfile=/tmp/master.pid
 vacuum=True
 max-requests=5000
-env=DJANGO_SETTINGS_MODULE=fala.settings
 processes=2
 harakiri=30
 logger-req=stdio

--- a/fala/settings/production.py
+++ b/fala/settings/production.py
@@ -1,0 +1,8 @@
+import os
+from .base import *  # noqa: F401,F403
+
+settings_required = ("SECRET_KEY", "ZENDESK_API_USERNAME", "ZENDESK_API_TOKEN")
+
+for key in settings_required:
+    if key not in os.environ:
+        raise Exception("'{}' Environment variable is required. please provide".format(key))

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -40,6 +40,26 @@ spec:
             secretKeyRef:
               name: sentry
               key: dsn
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret-key
+              key: SECRET_KEY
+        - name: ZENDESK_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: zendesk-api
+              key: ZENDESK_API_TOKEN
+        - name: ZENDESK_API_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: zendesk-api
+              key: ZENDESK_API_USERNAME
+        - name: GA_ID
+          valueFrom:
+            secretKeyRef:
+              name: ga-id
+              key: GA_ID
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala-nginx:master
         name: nginx
         readinessProbe:

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -35,6 +35,10 @@ spec:
           value: ".laa-fala-production.apps.cloud-platform-live-0.k8s.integration.dsd.io .find-legal-advice.justice.gov.uk"
         - name: LAALAA_API_HOST
           value: https://prod.laalaa.dsd.io
+        - name: GA_ID
+          value: "UA-37377084-6"
+        - name: DJANGO_SETTINGS_MODULE
+          value: "fala.settings.production"
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
@@ -55,11 +59,6 @@ spec:
             secretKeyRef:
               name: zendesk-api
               key: ZENDESK_API_USERNAME
-        - name: GA_ID
-          valueFrom:
-            secretKeyRef:
-              name: ga-id
-              key: GA_ID
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala-nginx:master
         name: nginx
         readinessProbe:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -35,6 +35,8 @@ spec:
           value: .laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
         - name: LAALAA_API_HOST
           value: https://staging.laalaa.dsd.io
+        - name: DJANGO_SETTINGS_MODULE
+          value: "fala.settings.production"
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -35,8 +35,6 @@ spec:
           value: .laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
         - name: LAALAA_API_HOST
           value: https://staging.laalaa.dsd.io
-        - name: DJANGO_SETTINGS_MODULE
-          value: "fala.settings.production"
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -40,6 +40,21 @@ spec:
             secretKeyRef:
               name: sentry
               key: dsn
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret-key
+              key: SECRET_KEY
+        - name: ZENDESK_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: zendesk-api
+              key: ZENDESK_API_TOKEN
+        - name: ZENDESK_API_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: zendesk-api
+              key: ZENDESK_API_USERNAME
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-fala-nginx:master
         name: nginx
         readinessProbe:


### PR DESCRIPTION
## What does this pull request do?

Added the following configuration to the kubernetes deployment:
SECRET_KEY
ZENDESK_API_USERNAME
ZENDESK_API_TOKEN

## Any other changes that would benefit highlighting?

This includes changes to make the production application fail to boot without the required secrets. For production the DJANGO_SETTINGS_MODULE env var is set in the deployment.yml 