### PR TITLE
LGA-487 Service page offline fala

### DIFF
--- a/fala/templates/500.html
+++ b/fala/templates/500.html
@@ -13,14 +13,14 @@
         <header class="page-header">
           <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
         </header>
-        <p class="govuk-body">Try again later</p>
-        <p class="govuk-body">You can also <a class="govuk-link" href="http://solicitors.lawsociety.org.uk/">find a solicitor</a> on the Law Society website</p>
+        <p class="govuk-body">Try again later.</p>
+        <p class="govuk-body">You can also <a class="govuk-link" href="http://solicitors.lawsociety.org.uk/">find a solicitor</a> on the Law Society website.</p>
         <p class="govuk-body">Search using your location, then select 'Accepts legal aid' to show legal aid solicitors near you.</p>
       </div>
     </div>
   </main>
 </div>
-{% endblock %
+{% endblock %}
 
 {% block after_main_js %}
   {% if GA_ID %}

--- a/fala/templates/500.html
+++ b/fala/templates/500.html
@@ -3,12 +3,24 @@
 {% block before_main_js %}{% endblock %}
 {% block main_js %}{% endblock %}
 
+{% block page_title %}{{ _('Sorry, there is a problem with the service - Check if you can get legal aid - GOV.UK') }} - {{ super() }}{% endblock %}
+
 {% block content %}
-  <header class="page-header">
-    <h1>This service is temporarily unavailable</h1>
-  </header>
-  <p>This service is not available right now, but we’re working hard to get things up and running again.</p>
-{% endblock %}
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <header class="page-header">
+          <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+        </header>
+        <p class="govuk-body">Try again later</p>
+        <p class="govuk-body">You can also <a class="govuk-link" href="http://solicitors.lawsociety.org.uk/">find a solicitor</a> on the Law Society website</p>
+        <p class="govuk-body">Search using your location, then select 'Accepts legal aid' to show legal aid solicitors near you.</p>
+      </div>
+    </div>
+  </main>
+</div>
+{% endblock %
 
 {% block after_main_js %}
   {% if GA_ID %}


### PR DESCRIPTION
## What does this pull request do?
[Service is down designs ](https://docs.google.com/document/d/1XoybV_YCyrz2-K12r9cUtf7Z3EIsjNSoDbRSdBhjO_8/edit)
[LGA-487 Create a service offline page when FALA can't communicate with LALA API](https://dsdmoj.atlassian.net/browse/LGA-543)

This pull request changes the content of the service page offline message in FALA if backend or laalaa are down.

In order to view this service offline page paste the following code into fala/urls: 
```
if settings.DEBUG:
    from django.views.defaults import server_error
    urlpatterns += [
        url(r'^500/$', server_error),
    ]
```
Then...
run locally, without running LALA or CLA backend,  adding '/500' at the end of the url that is generated. 

## Any other changes that would benefit highlighting?

Intentionally left blank.
