### PR TITLE
Enable TLS using new cloud platform spec

### DIFF
--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -31,5 +31,6 @@ kubectl set image --filename="$NAMESPACE_DIR/deployment.yml" --local --output=ya
     --filename=/dev/stdin \
     --filename="$NAMESPACE_DIR/service.yml" \
     --filename="$NAMESPACE_DIR/ingress.yml" \
-    --filename="$NAMESPACE_DIR/dashboard.yml"
+    --filename="$NAMESPACE_DIR/dashboard.yml" \
+    --filename="$NAMESPACE_DIR/certificate.yml"
 

--- a/kubernetes_deploy/production/certificate.yml
+++ b/kubernetes_deploy/production/certificate.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: fala
+  namespace: laa-fala-production
+spec:
+  secretName: fala-tls-certificate
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: 'find-legal-advice.justice.gov.uk'
+  acme:
+    config:
+    - domains:
+      - 'find-legal-advice.justice.gov.uk'
+      dns01:
+        provider: route53-dsd

--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -4,6 +4,9 @@ metadata:
   name: laa-fala
   namespace: laa-fala-production
 spec:
+  tls:
+  - hosts:
+    - laa-fala-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
   rules:
   - host: laa-fala-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
     http:

--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -7,8 +7,18 @@ spec:
   tls:
   - hosts:
     - laa-fala-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
+  - hosts:
+    - find-legal-advice.justice.gov.uk
+    secretName: fala-tls-certificate
   rules:
   - host: laa-fala-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: laa-fala
+          servicePort: 80
+  - host: find-legal-advice.justice.gov.uk
     http:
       paths:
       - path: /

--- a/kubernetes_deploy/staging/certificate.yml
+++ b/kubernetes_deploy/staging/certificate.yml
@@ -1,0 +1,2 @@
+# Empty file is required as files need to exist on both staging and
+# production for the deployment

--- a/kubernetes_deploy/staging/ingress.yml
+++ b/kubernetes_deploy/staging/ingress.yml
@@ -4,6 +4,9 @@ metadata:
   name: laa-fala
   namespace: laa-fala-staging
 spec:
+  tls:
+  - hosts:
+    - laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
   rules:
   - host: laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
     http:


### PR DESCRIPTION
## What does this pull request do?

Enable TLS in the Ingress resource.

## Any other changes that would benefit highlighting?

This was implicitly been done by the cloud platforms team before however recent changes mean that we need to explicitly do this
