### PR TITLE
LGA-148 - Use Google Maps API key from kubernetes

### DIFF
--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -21,6 +21,7 @@ class AdviserView(TemplateView):
                 "data": form.search(),
                 "current_url": current_url,
                 "GA_ID": settings.GA_ID,
+                "GOOGLE_MAPS_API_KEY": settings.GOOGLE_MAPS_API_KEY,
                 "LAALAA_API_HOST": settings.LAALAA_API_HOST,
             }
         )

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -139,6 +139,8 @@ ZENDESK_REQUESTER_ID = os.environ.get("ZENDESK_REQUESTER_ID", 649762516)
 
 GA_ID = os.environ.get("GA_ID")
 
+GOOGLE_MAPS_API_KEY = os.environ.get("GOOGLE_MAPS_API_KEY", "")
+
 # .local.py overrides all the common settings.
 try:
     from .local import *  # noqa: F401,F403

--- a/fala/settings/production.py
+++ b/fala/settings/production.py
@@ -1,7 +1,7 @@
 import os
 from .base import *  # noqa: F401,F403
 
-settings_required = ("SECRET_KEY", "ZENDESK_API_USERNAME", "ZENDESK_API_TOKEN")
+settings_required = ("SECRET_KEY", "ZENDESK_API_USERNAME", "ZENDESK_API_TOKEN", "GOOGLE_MAPS_API_KEY")
 
 for key in settings_required:
     if key not in os.environ:

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -89,7 +89,7 @@
       ga('send', 'pageview');
     </script>
   {% endif %}
-  <script src="//maps.googleapis.com/maps/api/js"></script>
+  <script src="//maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}"></script>
   <script>
     window.LABELS = {
       loading: "{{ _('Loading…') }}"

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -39,6 +39,11 @@ spec:
           value: "UA-37377084-6"
         - name: DJANGO_SETTINGS_MODULE
           value: "fala.settings.production"
+        - name: GOOGLE_MAPS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: google-maps
+              key: GOOGLE_MAPS_API_KEY
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -40,10 +40,7 @@ spec:
         - name: DJANGO_SETTINGS_MODULE
           value: "fala.settings.production"
         - name: GOOGLE_MAPS_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: google-maps
-              key: GOOGLE_MAPS_API_KEY
+          value: AIzaSyC3yE4iqalLcys8ZbjdZAPjDpcYuwd2GME
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -33,6 +33,11 @@ spec:
         env:
         - name: ALLOWED_HOSTS
           value: .laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
+        - name: GOOGLE_MAPS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: google-maps
+              key: GOOGLE_MAPS_API_KEY
         - name: LAALAA_API_HOST
           value: https://staging.laalaa.dsd.io
         - name: SENTRY_DSN

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -34,10 +34,7 @@ spec:
         - name: ALLOWED_HOSTS
           value: .laa-fala-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
         - name: GOOGLE_MAPS_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: google-maps
-              key: GOOGLE_MAPS_API_KEY
+          value: AIzaSyDdz1B1M2-2r0CQKJPscvmNEyxGwSZkXJk
         - name: LAALAA_API_HOST
           value: https://staging.laalaa.dsd.io
         - name: SENTRY_DSN


### PR DESCRIPTION
Injects the api key into the env from kubernetes, on staging and
production
Defaults to the empty string when absent (which produces the existing
behaviour of warning dialogue and watermark when passed as the key)

## What does this pull request do?

Required.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
