### PR TITLE
LGA-587 - Update LAALAA_API_HOST env var on staging pods

### DIFF
--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -36,7 +36,7 @@ spec:
         - name: GOOGLE_MAPS_API_KEY
           value: AIzaSyDdz1B1M2-2r0CQKJPscvmNEyxGwSZkXJk
         - name: LAALAA_API_HOST
-          value: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/
+          value: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -36,7 +36,7 @@ spec:
         - name: GOOGLE_MAPS_API_KEY
           value: AIzaSyDdz1B1M2-2r0CQKJPscvmNEyxGwSZkXJk
         - name: LAALAA_API_HOST
-          value: https://staging.laalaa.dsd.io
+          value: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## What does this pull request do?
Configures `staging` deployments of the site to use the new domain for the staging instance of the legal adviser API, which is the kubernetes-deployed version.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
