### PR TITLE
LGA-813 - Fetch LAALAA provider categories from LAALAA endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,8 @@ jobs:
           command: |
             pip install virtualenv
             virtualenv lint-env
+            source lint-env/bin/activate
+            pip install pip==18.1
       - restore_cache:
           keys:
             - pip-v1-{{ checksum "requirements/lint.txt" }}
@@ -109,6 +111,8 @@ jobs:
           command: |
             pip install virtualenv
             virtualenv env
+            source env/bin/activate
+            pip install pip==18.1
       - restore_cache:
           keys:
             - pip-v1-{{ checksum "requirements/base.txt" }}
@@ -141,7 +145,7 @@ jobs:
       - deploy:
           name: Deploy fala to staging
           command: |
-            .circleci/deploy_to_kubernetes staging ${ECR_DOCKER_REPO_BASE}-webapp ${ECR_DOCKER_REPO_BASE}-nginx 
+            .circleci/deploy_to_kubernetes staging ${ECR_DOCKER_REPO_BASE}-webapp ${ECR_DOCKER_REPO_BASE}-nginx
       - deploy:
           name: Notify Slack channel
           command: .circleci/notify_slack_channel staging
@@ -159,7 +163,7 @@ jobs:
       - deploy:
           name: Deploy fala to production
           command: |
-            .circleci/deploy_to_kubernetes production ${ECR_DOCKER_REPO_BASE}-webapp ${ECR_DOCKER_REPO_BASE}-nginx 
+            .circleci/deploy_to_kubernetes production ${ECR_DOCKER_REPO_BASE}-webapp ${ECR_DOCKER_REPO_BASE}-nginx
       - deploy:
           name: Notify Slack channel
           command: .circleci/notify_slack_channel production

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ WORKDIR /home/app
 
 # Install Python dependencies
 COPY ./requirements/base.txt ./requirements.txt
+RUN pip3 install -U setuptools pip==18.1 wheel
 RUN pip3 install --user --requirement ./requirements.txt
 
 # Install npm dependencies

--- a/fala/apps/laalaa/api.py
+++ b/fala/apps/laalaa/api.py
@@ -3,45 +3,24 @@ from urllib.parse import urlencode
 from collections import OrderedDict
 import requests
 
-try:
-    from django.conf import settings
-    from django.utils.translation import gettext_lazy as _
+from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
-    LAALAA_API_HOST = settings.LAALAA_API_HOST
-except ImportError:
-    from flask import current_app
-    from flask.ext.babel import lazy_gettext as _
-
-    LAALAA_API_HOST = current_app.config["LAALAA_API_HOST"]
+from cla_common.laalaa import LaalaaProviderCategoriesApiClient, LaaLaaError
 
 try:
     basestring
 except NameError:
     basestring = str
 
-PROVIDER_CATEGORY_CHOICES = (
-    ("aap", _("Claims Against Public Authorities")),
-    ("med", _("Clinical negligence")),
-    ("com", _("Community care")),
-    ("crm", _("Crime")),
-    ("deb", _("Debt")),
-    ("disc", _("Discrimination")),
-    ("edu", _("Education")),
-    ("mat", _("Family")),
-    ("fmed", _("Family mediation")),
-    ("hou", _("Housing")),
-    ("immas", _("Immigration or asylum")),
-    ("mhe", _("Mental health")),
-    ("pl", _("Prison law")),
-    ("pub", _("Public law")),
-    ("wb", _("Welfare benefits")),
-)
 
+def get_categories():
+    categories = LaalaaProviderCategoriesApiClient.singleton(settings.LAALAA_API_HOST, _).get_categories()
+    return [item for item in sorted(categories.items())]
+
+
+PROVIDER_CATEGORY_CHOICES = get_categories()
 PROVIDER_CATEGORIES = OrderedDict(PROVIDER_CATEGORY_CHOICES)
-
-
-class LaaLaaError(Exception):
-    pass
 
 
 def kwargs_to_urlparams(**kwargs):
@@ -50,7 +29,9 @@ def kwargs_to_urlparams(**kwargs):
 
 
 def laalaa_url(**kwargs):
-    return "{host}/legal-advisers/?{params}".format(host=LAALAA_API_HOST, params=kwargs_to_urlparams(**kwargs))
+    return "{host}/legal-advisers/?{params}".format(
+        host=settings.LAALAA_API_HOST, params=kwargs_to_urlparams(**kwargs)
+    )
 
 
 def laalaa_search(**kwargs):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,4 @@ uwsgi==2.0.17
 requests==2.7.0
 django_jinja==1.4.1
 logstash-formatter==0.5.14
+git+git://github.com/ministryofjustice/cla_common.git@0.3.3#egg=cla_common==0.3.3


### PR DESCRIPTION
## What does this pull request do?

Fetch LAALAA provider categories from LAALAA endpoint instead of a local constant in this app

## Any other changes that would benefit highlighting?

Downgrades pip to 18.1 due to cla_common packaging not being compatible with pip 19, see https://github.com/ministryofjustice/cla_public/pull/800 for more details

Requires https://github.com/ministryofjustice/laa-legal-adviser-api/pull/137 to be LAALAA master before merging in this PR

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
