### PR TITLE
LGA-634 - Start using Kubernetes cloud platform hosted LAALAA_API_HOST for production

### DIFF
--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -34,7 +34,7 @@ spec:
         - name: ALLOWED_HOSTS
           value: ".laa-fala-production.apps.cloud-platform-live-0.k8s.integration.dsd.io .find-legal-advice.justice.gov.uk"
         - name: LAALAA_API_HOST
-          value: https://prod.laalaa.dsd.io
+          value: https://laa-legal-adviser-api-production.cloud-platform.service.justice.gov.uk
         - name: GA_ID
           value: "UA-37377084-6"
         - name: DJANGO_SETTINGS_MODULE


### PR DESCRIPTION
## What does this pull request do?

Start using Kubernetes cloud platform hosted LAALAA_API_HOST for production

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
