### PR TITLE
LGA-905 - Set week-long default expiry for staticfiles

### DIFF
--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -54,6 +54,7 @@ AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME")
 AWS_DEFAULT_ACL = None
+AWS_QUERYSTRING_EXPIRE = 60 * 60 * 24 * 7
 
 STATIC_URL = "/static/"
 STATIC_ROOT = root("static")


### PR DESCRIPTION
## What does this pull request do?
This affects the expiry of presigned urls for static files included in the html using the static tag, eg the stylesheets themselves. These were defaulting to an hour, which was fine for page load but meant that pages left open in a browser and then returned to after the computer had been slept or restarted were loading without styling. This lengthens the expiry time to the maximum of a week to avoid that happening.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
