### PR TITLE
LGA-1064 town missing from sentence bug

### DIFF
--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -32,7 +32,7 @@ class AdviserSearchForm(forms.Form):
         max_length=30,
         help_text=_("For example, SW1H 9AJ"),
         required=False,
-        widget=FalaTextInput(attrs={"class": "govuk-input govuk-!-width-one-third laa-postcode"}),
+        widget=FalaTextInput(attrs={"class": "govuk-input govuk-!-width-one-third"}),
     )
 
     name = forms.CharField(

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -8,8 +8,10 @@
           {{ result_count }} results in total. Showing {{ page_count }} results around
         {% endtrans %}
         <strong>{{ data.origin.postcode }}</strong>
-        {% if form.name.value() %}
+        {%- if form.name.value() -%}
           {{ _('matching') }} <strong>{{ form.name.value() }}</strong>.
+        {%- else -%}
+          .
         {% endif %}
       {% elif request.GET.get('postcode','') %}
         {% set city_list = [] %}
@@ -52,18 +54,25 @@
         {% endfor %}
         {% set city_list = city_list|join('; ') %}
 
-        {% trans result_count=data.count, page_count=data.results|length, city_name=city_list %}
-          Showing {{ page_count }} result for <strong>{{ city_name }}</strong>.
-        {% pluralize %}
-          {{ result_count }} results in total. Showing {{ page_count }} results for <strong>{{ city_name }}</strong>.
-        {% endtrans %}
-      {% elif form.name.value() %}
+        {% if form.name.value() %}
+          {% trans result_count=data.count, page_count=data.results|length, org_name=form.name.value(), city_name=city_list %}
+            Showing {{ page_count }} result matching <strong>{{ org_name }}</strong> for <strong>{{ city_name }}</strong>.
+          {% pluralize %}
+            {{ result_count }} results in total. Showing {{ page_count }} results marching <strong>{{ org_name }}</strong> for <strong>{{ city_name }}</strong>.
+          {% endtrans %}
+        {% else %}
+          {% trans result_count=data.count, page_count=data.results|length, city_name=city_list %}
+            Showing {{ page_count }} result for <strong>{{ city_name }}</strong>.
+          {% pluralize %}
+            {{ result_count }} results in total. Showing {{ page_count }} results for <strong>{{ city_name }}</strong>.
+          {% endtrans %}
+        {% endif %}
+      {% else %}
         {% trans result_count=data.count, page_count=data.results|length, org_name=form.name.value() %}
           Showing {{ page_count }} result for <strong>{{ org_name }}</strong>.
         {% pluralize %}
           {{ result_count }} results in total. Showing {{ page_count }} results for <strong>{{ org_name }}</strong>.
         {% endtrans %}
-      {% else %}
       {% endif %}
     </p>
 

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -8,7 +8,7 @@
           {{ result_count }} results in total. Showing {{ page_count }} results around
         {% endtrans %}
         <strong>{{ data.origin.postcode }}</strong>
-        {%- if form.name.value() -%}
+        {%- if form.name.value() %}
           {{ _('matching') }} <strong>{{ form.name.value() }}</strong>.
         {%- else -%}
           .
@@ -52,19 +52,19 @@
             {% do city_list.append( location ) %}
           {% endif %}
         {% endfor %}
-        {% set city_list = city_list|join('; ') %}
+        {% set city_list = "<strong>" ~ city_list|join('</strong>; <strong>') ~ "</strong>" %}
 
         {% if form.name.value() %}
-          {% trans result_count=data.count, page_count=data.results|length, org_name=form.name.value(), city_name=city_list %}
-            Showing {{ page_count }} result matching <strong>{{ org_name }}</strong> for <strong>{{ city_name }}</strong>.
+          {% trans result_count=data.count, page_count=data.results|length, org_name=form.name.value(), city_name=city_list|safe %}
+            Showing {{ page_count }} result matching <strong>{{ org_name }}</strong> for {{ city_name }}.
           {% pluralize %}
-            {{ result_count }} results in total. Showing {{ page_count }} results marching <strong>{{ org_name }}</strong> for <strong>{{ city_name }}</strong>.
+            {{ result_count }} results in total. Showing {{ page_count }} results marching <strong>{{ org_name }}</strong> for {{ city_name }}.
           {% endtrans %}
         {% else %}
-          {% trans result_count=data.count, page_count=data.results|length, city_name=city_list %}
-            Showing {{ page_count }} result for <strong>{{ city_name }}</strong>.
+          {% trans result_count=data.count, page_count=data.results|length, city_name=city_list|safe %}
+            Showing {{ page_count }} result for {{ city_name }}.
           {% pluralize %}
-            {{ result_count }} results in total. Showing {{ page_count }} results for <strong>{{ city_name }}</strong>.
+            {{ result_count }} results in total. Showing {{ page_count }} results for {{ city_name }}.
           {% endtrans %}
         {% endif %}
       {% else %}

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -11,29 +11,41 @@
         {% if form.name.value() %}
           {{ _('matching') }} <strong>{{ form.name.value() }}</strong>.
         {% endif %}
-      {% elif form.name.value() %}
-        {% trans result_count=data.count, page_count=data.results|length, org_name=form.name.value() %}
-          Showing {{ page_count }} result for <strong>{{ org_name }}</strong>.
-        {% pluralize %}
-          {{ result_count }} results in total. Showing {{ page_count }} results for <strong>{{ org_name }}</strong>.
-        {% endtrans %}
-      {% else %}
+      {% elif request.GET.get('postcode','') %}
         {% set city_list = [] %}
         {% for item in data.results %}
+          {#
+            To prevent the same place appearing twice in the list, we harmonise the ones with commin misspellings.
+            All ones with a common middle element (e.g. by the) are hyphenated and lower cased (remove hyphens, change case, replace hyphens).
+            Thornton-Cleveleys is always hyphenated.
+            Hull is always Kingston upon Hull (not hyphenated).
+          #}
           {% set location = item.location.city
             |replace("-"," ")
+            |replace(" By The "," by the ")
+            |replace(" In The "," in the ")
+            |replace(" On The "," on the ")
+            |replace(" By "," by ")
             |replace(" In "," in ")
             |replace(" On "," on ")
             |replace(" Cum "," cum ")
             |replace(" Upon "," upon ")
             |replace(" Under "," under ")
             |replace(" Super "," super ")
+            |replace(" by the ","-by-the-")
+            |replace(" in the ","-in-the-")
+            |replace(" on the ","-on-the-")
+            |replace(" by ","-by-")
             |replace(" in ","-in-")
             |replace(" on ","-on-")
             |replace(" cum ","-cum-")
             |replace(" upon ","-upon-")
             |replace(" under ","-under-")
-            |replace(" super ","-super-") %}
+            |replace(" super ","-super-")
+            |replace("Thornton Cleveleys","Thornton-Cleveleys")
+            |replace("Hull","Kingston upon Hull")
+            |replace("Kingston-upon-Kingston upon Hull","Kingston upon Hull")
+          %}
           {% if location not in city_list %}
             {% do city_list.append( location ) %}
           {% endif %}
@@ -45,6 +57,13 @@
         {% pluralize %}
           {{ result_count }} results in total. Showing {{ page_count }} results for <strong>{{ city_name }}</strong>.
         {% endtrans %}
+      {% elif form.name.value() %}
+        {% trans result_count=data.count, page_count=data.results|length, org_name=form.name.value() %}
+          Showing {{ page_count }} result for <strong>{{ org_name }}</strong>.
+        {% pluralize %}
+          {{ result_count }} results in total. Showing {{ page_count }} results for <strong>{{ org_name }}</strong>.
+        {% endtrans %}
+      {% else %}
       {% endif %}
     </p>
 

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -8,14 +8,42 @@
           {{ result_count }} results in total. Showing {{ page_count }} results around
         {% endtrans %}
         <strong>{{ data.origin.postcode }}</strong>
-        {% if  form.name.value() %}
+        {% if form.name.value() %}
           {{ _('matching') }} <strong>{{ form.name.value() }}</strong>.
         {% endif %}
-      {% else %}
+      {% elif form.name.value() %}
         {% trans result_count=data.count, page_count=data.results|length, org_name=form.name.value() %}
-          Showing {{ page_count }} result for <strong>{{ org_name }}</strong>
+          Showing {{ page_count }} result for <strong>{{ org_name }}</strong>.
         {% pluralize %}
           {{ result_count }} results in total. Showing {{ page_count }} results for <strong>{{ org_name }}</strong>.
+        {% endtrans %}
+      {% else %}
+        {% set city_list = [] %}
+        {% for item in data.results %}
+          {% set location = item.location.city
+            |replace("-"," ")
+            |replace(" In "," in ")
+            |replace(" On "," on ")
+            |replace(" Cum "," cum ")
+            |replace(" Upon "," upon ")
+            |replace(" Under "," under ")
+            |replace(" Super "," super ")
+            |replace(" in ","-in-")
+            |replace(" on ","-on-")
+            |replace(" cum ","-cum-")
+            |replace(" upon ","-upon-")
+            |replace(" under ","-under-")
+            |replace(" super ","-super-") %}
+          {% if location not in city_list %}
+            {% do city_list.append( location ) %}
+          {% endif %}
+        {% endfor %}
+        {% set city_list = city_list|join('; ') %}
+
+        {% trans result_count=data.count, page_count=data.results|length, city_name=city_list %}
+          Showing {{ page_count }} result for <strong>{{ city_name }}</strong>.
+        {% pluralize %}
+          {{ result_count }} results in total. Showing {{ page_count }} results for <strong>{{ city_name }}</strong>.
         {% endtrans %}
       {% endif %}
     </p>


### PR DESCRIPTION
## What does this pull request do?

New logic to isolate the towns from the addresses of all results and displays them in the sentence.
As part of this, we harmonize some place name variants so the same place isn't listed twice.  

## Any other changes that would benefit highlighting?

Removes all-caps class `laa-postcode` for postcode field (it isn't solely for postcodes).
Adds in missing full stop from postcode and org name sentence (and elsewhere where it was missing).

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
