### PR TITLE
LGA-1037 Input fields style update

### DIFF
--- a/fala/assets-src/sass/_google-translate.scss
+++ b/fala/assets-src/sass/_google-translate.scss
@@ -1,4 +1,34 @@
-// use govuk element style
-.goog-te-combo {
-  @extend .form-control
+select.goog-te-combo {
+  font-size: 16px;
+  font-family: "GDS Transport",Arial,sans-serif;
+  height: 2.5rem;
+  padding: 5px;
+  border: 2px solid $govuk-text-colour;
+
+  &:focus {
+    outline: 3px solid $govuk-focus-colour;
+    outline-offset: 0;
+    -webkit-box-shadow: inset 0 0 0 2px;
+    box-shadow: inset 0 0 0 2px;
+  }
+}
+
+select.goog-te-combo option {
+  display:none;
+  &[value=""],
+  &[value|=en],
+  &[value|=cy],
+  &[value|=gd],
+  &[value|=ga] {
+    display:block;
+  }
+}
+
+a.goog-logo-link:focus {
+  outline: 3px solid transparent;
+  color: $govuk-text-colour;
+  background-color: $govuk-focus-colour;
+  -webkit-box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-text-colour;
+  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-text-colour;
+  text-decoration: none;
 }

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -1,4 +1,28 @@
 {% if data and data.count and data.count > 0 %}
+  {% if data.origin.postcode %}
+    {% if data.origin.postcode.startswith("BT") %}
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning </span>
+            Legal Aid is different in Northern Ireland. Visit
+            <a class="govuk-link" href="https://www.nidirect.gov.uk/articles/legal-aid-schemes">nidirect.gov.uk</a>
+            for more information.
+        </strong>
+      </div>
+    {% endif %}
+    {% if data.origin.postcode[:2] in ("AB","DD","DG","EH","FK","G1","G2","G3","G4","G5","G6","G7","G8","G9","G0","HS","IV","KA","KW","KY","ML","PA","PH","TD","ZE",) %}
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning </span>
+            Legal Aid is different in Scotland. Visit
+            <a class="govuk-link" href="https://www.mygov.scot/legal-aid/">mygov.scot</a>
+            for more information.
+        </strong>
+      </div>
+    {% endif %}
+  {% endif %}
   <section class="legal-adviser-results">
     <p class="govuk-body">
       {% if data.origin %}
@@ -171,4 +195,37 @@
   {% call alert(title=_('No results')) %}
     {{ _('There are no results matching your search criteria.') }}
   {% endcall %}
+{% elif data|length == 0 %}
+  {% set searched_postcode = request.GET.get('postcode','')[:2]|upper %}
+  {% if searched_postcode.startswith("IM") %}
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning </span>
+          Legal Aid is different on the Isle of Man. Visit
+          <a class="govuk-link" href="https://www.gov.im/categories/benefits-and-financial-support/legal-aid/">gov.im</a>
+          for more information.
+      </strong>
+    </div>
+  {% elif searched_postcode.startswith("JE") %}
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning </span>
+          Legal Aid is different in Jersey. Visit
+          <a class="govuk-link" href="https://www.legalaid.je/">legalaid.je</a>
+          for more information.
+      </strong>
+    </div>
+  {% elif searched_postcode.startswith("GY") %}
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning </span>
+          Legal Aid is different in Guernsey. Visit
+          <a class="govuk-link" href="https://www.gov.gg/legalaid">gov.gg</a>
+          for information about the process in Guernsey.
+      </strong>
+    </div>
+  {% endif %}
 {% endif %}

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -1,6 +1,36 @@
 {% if data and data.count and data.count > 0 %}
   {% if data.origin.postcode %}
-    {% if data.origin.postcode.startswith("BT") %}
+    {% if data.origin.postcode.startswith("IM") %}
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning </span>
+            Legal Aid is different on the Isle of Man. Visit
+            <a class="govuk-link" href="https://www.gov.im/categories/benefits-and-financial-support/legal-aid/">gov.im</a>
+            for more information.
+        </strong>
+      </div>
+    {% elif data.origin.postcode.startswith("JE") %}
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning </span>
+            Legal Aid is different in Jersey. Visit
+            <a class="govuk-link" href="https://www.legalaid.je/">legalaid.je</a>
+            for more information.
+        </strong>
+      </div>
+    {% elif data.origin.postcode.startswith("GY") %}
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning </span>
+            Legal Aid is different in Guernsey. Visit
+            <a class="govuk-link" href="https://www.gov.gg/legalaid">gov.gg</a>
+            for information about the process in Guernsey.
+        </strong>
+      </div>
+    {% elif data.origin.postcode.startswith("BT") %}
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
@@ -10,8 +40,7 @@
             for more information.
         </strong>
       </div>
-    {% endif %}
-    {% if data.origin.postcode[:2] in ("AB","DD","DG","EH","FK","G1","G2","G3","G4","G5","G6","G7","G8","G9","G0","HS","IV","KA","KW","KY","ML","PA","PH","TD","ZE",) %}
+    {% elif data.origin.postcode[:2] in ("AB","DD","DG","EH","FK","G1","G2","G3","G4","G5","G6","G7","G8","G9","G0","HS","IV","KA","KW","KY","ML","PA","PH","TD","ZE",) %}
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
@@ -196,6 +225,9 @@
     {{ _('There are no results matching your search criteria.') }}
   {% endcall %}
 {% elif data|length == 0 %}
+  {#
+    This is a repeat of the above as the current data set throws an error for Crown Dependency postcodes, so the above code doesn't fire.
+  #}
   {% set searched_postcode = request.GET.get('postcode','')[:2]|upper %}
   {% if searched_postcode.startswith("IM") %}
     <div class="govuk-warning-text">


### PR DESCRIPTION
## What does this pull request do?

Google translate field:
- makes drop-down GDS-like
- makes link highlight in the new GDS colour
- hides all non-British languages (like Chinese) so Welsh is easier to select

Postcode warnings:
- adds in warnings for non-English or Welsh postcodes.
- also adds in warnings for crown dependency postcodes if no postcode returned (in addition to the main method - just in case the postcode data is expanded to include these places in the future as it has done previously).

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
