### PR TITLE
LGA-1039 map and results styling

### DIFF
--- a/fala/assets-src/sass/_fala-results-js.scss
+++ b/fala/assets-src/sass/_fala-results-js.scss
@@ -108,7 +108,7 @@ $map-height: 500px;
           }
 
           &.s-highlighted {
-            background: $yellow;
+            background: $govuk-focus-colour;
           }
 
           &:first-child {
@@ -139,7 +139,7 @@ $map-height: 500px;
         height: $map-height - $_pagination-height;
 
         &:focus {
-          outline: 2px solid $yellow;
+          outline: 2px solid $govuk-focus-colour;
         }
       }
 

--- a/fala/assets-src/sass/_fala-results-js.scss
+++ b/fala/assets-src/sass/_fala-results-js.scss
@@ -137,6 +137,10 @@ $map-height: 500px;
       .search-results-list {
         overflow: auto;
         height: $map-height - $_pagination-height;
+
+        &:focus {
+          outline: none; //overrides browser default
+        }
       }
 
       .search-results-pagination {
@@ -144,7 +148,6 @@ $map-height: 500px;
         padding: 3px;
 
         @include media('>phone') {
-          background: $grey-4;
           margin: 0;
         }
       }

--- a/fala/assets-src/sass/_fala-results-js.scss
+++ b/fala/assets-src/sass/_fala-results-js.scss
@@ -30,7 +30,7 @@ $map-height: 500px;
     .org-categories {
       margin-top: 10px;
       padding-top: 5px;
-      border-top: 1px solid $grey-3;
+      border-top: 1px solid $govuk-border-colour;
       color: #444;
       background: none;
     }
@@ -65,7 +65,7 @@ $map-height: 500px;
       .search-results-container {
         height: $map-height;
         margin: 0 -1px;
-        border: 1px solid $grey-2;
+        border: 1px solid $govuk-border-colour;
       }
 
       .search-results {
@@ -74,7 +74,7 @@ $map-height: 500px;
         float: right;
         position: relative;
         width: $results-sidebar-width;
-        border-left: 1px solid $grey-2;
+        border-left: 1px solid $govuk-border-colour;
         margin-left: -1px;
 
         .fn {
@@ -104,7 +104,7 @@ $map-height: 500px;
           padding: 4px;
 
           &:hover {
-            background: $grey-4;
+            background: govuk-colour("light-grey");
           }
 
           &.s-highlighted {

--- a/fala/assets-src/sass/_fala-results-js.scss
+++ b/fala/assets-src/sass/_fala-results-js.scss
@@ -137,10 +137,6 @@ $map-height: 500px;
       .search-results-list {
         overflow: auto;
         height: $map-height - $_pagination-height;
-
-        &:focus {
-          outline: 2px solid $govuk-focus-colour;
-        }
       }
 
       .search-results-pagination {

--- a/fala/assets-src/sass/_fala-results-js.scss
+++ b/fala/assets-src/sass/_fala-results-js.scss
@@ -78,7 +78,7 @@ $map-height: 500px;
         margin-left: -1px;
 
         .fn {
-          color: $link-colour;
+          color: $govuk-link-colour;
         }
 
         .org-details {

--- a/fala/assets-src/sass/_fala-results.scss
+++ b/fala/assets-src/sass/_fala-results.scss
@@ -15,6 +15,10 @@
 
 // Common results
 
+a.org-summary:focus {
+  background:$govuk-focus-colour;
+}
+
 .find-legal-adviser {
   .street-address {
     white-space: pre;

--- a/fala/assets-src/sass/_fala-results.scss
+++ b/fala/assets-src/sass/_fala-results.scss
@@ -165,3 +165,116 @@ a.org-summary:focus {
     }
   }
 }
+
+// Pagination
+
+.moj-pagination {
+  // text-align: center;
+
+  @include govuk-media-query($from: desktop) {
+
+    // Alignment adjustments
+    margin-left: - govuk-spacing(1);
+    margin-right: - govuk-spacing(1);
+
+    // Hide whitespace between elements
+    font-size: 0;
+
+    // Trick to remove the need for floats
+    text-align: justify;
+
+    &:after {
+      content: '';
+      display: inline-block;
+      width: 100%;
+    }
+  }
+
+}
+
+.moj-pagination__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  @include govuk-media-query($from: desktop) {
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+}
+
+.moj-pagination__results {
+  @include govuk-media-query($from: desktop) {
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+}
+
+.moj-pagination__item {
+  @include govuk-font(19);
+  display: inline-block;
+}
+
+.moj-pagination__item--active,
+.moj-pagination__item--dots {
+  font-weight: bold;
+  height: 25px;
+  padding: govuk-spacing(1) govuk-spacing(2);
+  text-align: center;
+}
+
+.moj-pagination__item--dots {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.moj-pagination__item--prev .moj-pagination__link:before,
+.moj-pagination__item--next .moj-pagination__link:after {
+    display: inline-block;
+    height: 10px;
+    width: 10px;
+    border-style: solid;
+    color: govuk-colour("black");
+    background: transparent;
+    -webkit-transform: rotate(-45deg);
+    -ms-transform: rotate(-45deg);
+    transform: rotate(-45deg);
+    content: "";
+}
+
+.moj-pagination__item--prev .moj-pagination__link:before {
+    border-width: 3px 0 0 3px;
+    margin-right: govuk-spacing(1);
+}
+
+.moj-pagination__item--next .moj-pagination__link:after {
+    border-width: 0 3px 3px 0;
+    margin-left: govuk-spacing(1);
+}
+
+.moj-pagination__link {
+  display: block;
+  padding: govuk-spacing(1);
+  text-align: center;
+  text-decoration: none;
+  min-width: 25px;
+
+  &:link,
+  &:visited {
+    color: govuk-colour("blue");
+  }
+
+  &:hover {
+    color: govuk-colour("light-blue");
+   }
+
+  &:focus {
+    color: govuk-colour("black");
+  }
+
+}
+
+.moj-pagination__results {
+  padding: govuk-spacing(1);
+}

--- a/fala/assets-src/sass/_fala-results.scss
+++ b/fala/assets-src/sass/_fala-results.scss
@@ -39,8 +39,12 @@ a.org-summary:focus {
       list-style: none;
     }
 
+    .org-list-item:last-child {
+      border-bottom: 1px solid $govuk-border-colour;
+    }
+
     .org-list-item {
-      border-top: 1px solid $grey-3;
+      border-top: 1px solid $govuk-border-colour;
       padding: 10px 0;
       margin: 0;
       display: block;
@@ -65,7 +69,7 @@ a.org-summary:focus {
         font-weight: bold;
         color: #4a4a4a;
         border-radius: 100%;
-        border: 2px solid #ae4f47;
+        border: 2px solid #d34f45;
         float: left;
         margin: -1px 0 0 -26px;
         background: white;
@@ -80,8 +84,7 @@ a.org-summary:focus {
     }
 
     .distance {
-      color: $grey-1;
-      color: rgba($black, .6);
+      color: $govuk-text-colour;
       font-size: .8em;
       float: right;
       margin-right: -80px;

--- a/fala/assets-src/sass/_fala-results.scss
+++ b/fala/assets-src/sass/_fala-results.scss
@@ -137,7 +137,7 @@ a.org-summary:focus {
 
       a,
       span {
-        color: $link-colour;
+        color: $govuk-link-colour;
         font-size: .9em;
         line-height: 27px;
         display: block;
@@ -262,11 +262,11 @@ a.org-summary:focus {
 
   &:link,
   &:visited {
-    color: govuk-colour("blue");
+    color: $govuk-link-colour;
   }
 
   &:hover {
-    color: govuk-colour("light-blue");
+    color: $govuk-link-hover-colour;
    }
 
   &:focus {

--- a/fala/assets-src/sass/_fala-results.scss
+++ b/fala/assets-src/sass/_fala-results.scss
@@ -21,22 +21,10 @@ a.org-summary:focus {
 
 .find-legal-adviser {
 
-  .results-summary {
-    margin: 0;
-    padding: 20px 0;
-    border-top: 1px solid $grey-2;
-  }
-
-  .org-categories {
-    font-size: .85em;
-    line-height: 1.2;
-  }
-
   .search-results-list {
     .org-list {
       margin: 0;
       padding: 0;
-      list-style: none;
     }
 
     .org-list-item:last-child {
@@ -90,11 +78,6 @@ a.org-summary:focus {
       margin-right: -80px;
     }
 
-    .org-address {
-      margin: 0 0 5px;
-      float: left;
-    }
-
     .org-type {
       font-size: .9em;
       display: inline-block;
@@ -104,13 +87,6 @@ a.org-summary:focus {
       margin-left: 10px;
       float: right;
       color: white;
-    }
-
-    .org-categories {
-      background: $grey-4;
-      color: $grey-1;
-      margin: 8px 0 0 -27px;
-      padding: 7px 5px 5px 27px;
     }
 
     p {
@@ -128,44 +104,6 @@ a.org-summary:focus {
     overflow: hidden;
     border-top: 2px solid $grey-2;
     padding-top: 10px;
-
-    ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-    }
-
-    .results-nav {
-      margin: 0;
-
-      a,
-      span {
-        color: $govuk-link-colour;
-        font-size: .9em;
-        line-height: 27px;
-        display: block;
-        padding: 0 8px;
-        font-weight: bold;
-      }
-
-      a:hover {
-        text-decoration: none;
-      }
-
-      span {
-        font-weight: normal;
-        color: $grey-1;
-        cursor: default;
-      }
-    }
-
-    .results-nav-prev {
-      float: left;
-    }
-
-    .results-nav-next {
-      float: right;
-    }
   }
 }
 

--- a/fala/assets-src/sass/_fala-results.scss
+++ b/fala/assets-src/sass/_fala-results.scss
@@ -20,9 +20,6 @@ a.org-summary:focus {
 }
 
 .find-legal-adviser {
-  .street-address {
-    white-space: pre;
-  }
 
   .results-summary {
     margin: 0;

--- a/fala/assets-src/sass/_fala-results.scss
+++ b/fala/assets-src/sass/_fala-results.scss
@@ -1,3 +1,18 @@
+// Map styling
+.gm-style {
+  a:focus {
+    outline: solid 2px $govuk-focus-colour;
+    background-color: $govuk-focus-colour;
+  }
+  button:focus,
+  div[role=button]:focus {
+    background-color:$govuk-focus-colour ! important;
+    outline:$govuk-focus-colour 2px solid;
+  }
+}
+
+
+
 // Common results
 
 .find-legal-adviser {
@@ -79,7 +94,8 @@
     .org-type {
       font-size: .9em;
       display: inline-block;
-      background: $pink;
+      background: $govuk-brand-colour;
+      font-weight: 700;
       padding: 2px 5px 0;
       margin-left: 10px;
       float: right;

--- a/fala/assets-src/sass/main.scss
+++ b/fala/assets-src/sass/main.scss
@@ -100,3 +100,15 @@ p.govuk-body-l:last-child {
 .gds-header__error {
   border-bottom: 10px solid $govuk-error-colour;
 }
+
+.gm-style {
+  a:focus {
+    outline: solid 2px $govuk-focus-colour;
+    background-color: $govuk-focus-colour;
+  }
+  button:focus,
+  div[role=button]:focus {
+    background-color:$govuk-focus-colour ! important;
+    outline:$govuk-focus-colour 2px solid;
+  }
+}

--- a/fala/assets-src/sass/main.scss
+++ b/fala/assets-src/sass/main.scss
@@ -100,15 +100,3 @@ p.govuk-body-l:last-child {
 .gds-header__error {
   border-bottom: 10px solid $govuk-error-colour;
 }
-
-.gm-style {
-  a:focus {
-    outline: solid 2px $govuk-focus-colour;
-    background-color: $govuk-focus-colour;
-  }
-  button:focus,
-  div[role=button]:focus {
-    background-color:$govuk-focus-colour ! important;
-    outline:$govuk-focus-colour 2px solid;
-  }
-}

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -146,8 +146,8 @@
                     <span class="fn org">{{ item.organisation.name }}</span>
                   </h3>
                   {% if item.distance %}
-                    <div class="distance">
-                      <span class="u-vh">{{ _('Distance') }}</span>
+                    <div class="govuk-body-s distance">
+                      <span class="govuk-visually-hidden">{{ _('Distance') }}</span>
                       {% trans miles=item.distance|round(2) %}{{ miles }} miles{% endtrans %}
                     </div>
                   {% endif %}

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -53,6 +53,7 @@
     {% endif %}
   {% endif %}
   <section class="legal-adviser-results">
+    <h2 class="govuk-visually-hidden">_('Results')</h2><!--for screen readers only-->
     <p class="govuk-body">
       {% if data.origin %}
         {% trans page_count=data.results|length, result_count=data.count %}
@@ -156,7 +157,7 @@
                     <div class="org-type">{{ item.location.type|replace('Office', '') }}</div>
                   {% endif %}
                   <p class="govuk-body-s org-address">
-                    <span class="sr-only">{{ _('Address') }}:</span>
+                    <span class="govuk-visually-hidden">{{ _('Address') }}:</span>
                     <span class="adr">
                       <span class="street-address">{{ item.location.address }}</span>
                       <span class="city">{{ item.location.city }}</span>
@@ -176,11 +177,11 @@
                     </p>
                   {% endif %}
                   {% if item.categories|length %}
-                    <div class="org-categories" role="list">
-                      <div class="sr-only">{{ _('Categories of law') }}</div>
+                    <h4 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-bottom-2">{{ _('Categories of law') }}</h4>
+                    <ul class="govuk-list govuk-list--bullet govuk-!-font-size-14" role="list">
                       {% for cat in item.categories %}
                         {% if cat %}
-                          <span class="org-category" role="listitem">{{ cat }}</span>
+                          <li class="govuk-!-margin-0" role="listitem">{{ cat }}</li>
                           {%- if not loop.last %},{% endif %}
                         {% endif %}
                       {% endfor %}

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -198,9 +198,9 @@
             <ul class="moj-pagination__list">
               {% if data.previous %}
                 {% set prev_page = data.previous|to_fala_page_url(current_url) %}
-                <li class="moj-pagination__item  moj-pagination__item--prev">
+                <li class="moj-pagination__item  moj-pagination__item--prev" style="float:left;">
                   <a class="govuk-link moj-pagination__link govuk-!-font-size-16"
-                    style="float:left;padding-bottom:2px;padding-top:2px;"
+                    style="padding-bottom:2px;"
                     href="{{ prev_page|replace('organisation_', '') }}"
                     data-page="{{ prev_page|query_to_dict('page')|first }}"
                   >
@@ -210,9 +210,9 @@
               {% endif %}
               {% if data.next %}
                 {% set next_page = data.next|to_fala_page_url(current_url) %}
-                <li class="moj-pagination__item  moj-pagination__item--next">
+                <li class="moj-pagination__item  moj-pagination__item--next" style="float:right;">
                   <a class="govuk-link moj-pagination__link govuk-!-font-size-16"
-                    style="float:right;padding-bottom:2px;padding-top:2px;"
+                    style="padding-bottom:2px;"
                     href="{{ next_page|replace('organisation_', '') }}"
                     data-page="{{ next_page|query_to_dict('page')|first }}"
                   >

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -185,7 +185,7 @@
                           {%- if not loop.last %},{% endif %}
                         {% endif %}
                       {% endfor %}
-                    </div>
+                    </ul>
                   {% endif %}
                 </div>
               </li>

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -199,8 +199,11 @@
               {% if data.previous %}
                 {% set prev_page = data.previous|to_fala_page_url(current_url) %}
                 <li class="moj-pagination__item  moj-pagination__item--prev">
-                  <a class="moj-pagination__link" href="{{ prev_page|replace('organisation_', '') }}"
-                     data-page="{{ prev_page|query_to_dict('page')|first }}">
+                  <a class="govuk-link moj-pagination__link govuk-!-font-size-16"
+                    style="float:left;padding-bottom:2px;padding-top:2px;"
+                    href="{{ prev_page|replace('organisation_', '') }}"
+                    data-page="{{ prev_page|query_to_dict('page')|first }}"
+                  >
                     {{ _('Previous') }}<span class="govuk-visually-hidden"> {{ _('set of pages') }}</span>
                   </a>
                 </li>
@@ -208,8 +211,11 @@
               {% if data.next %}
                 {% set next_page = data.next|to_fala_page_url(current_url) %}
                 <li class="moj-pagination__item  moj-pagination__item--next">
-                  <a class="moj-pagination__link" href="{{ next_page|replace('organisation_', '') }}"
-                     data-page="{{ next_page|query_to_dict('page')|first }}">
+                  <a class="govuk-link moj-pagination__link govuk-!-font-size-16"
+                    style="float:right;padding-bottom:2px;padding-top:2px;"
+                    href="{{ next_page|replace('organisation_', '') }}"
+                    data-page="{{ next_page|query_to_dict('page')|first }}"
+                  >
                     {{ _('Next') }}<span class="govuk-visually-hidden"> {{ _('set of pages') }}</span>
                   </a>
                 </li>

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -195,7 +195,7 @@
         {% if data.previous or data.next %}
           <nav class="search-results-pagination">
             <p class="govuk-visually-hidden" aria-labelledby="pagination-label">{{ _('Results navigation') }}</p>
-            <ul class="moj-pagination__list">
+            <ul class="moj-pagination__list" style="width:100%;">
               {% if data.previous %}
                 {% set prev_page = data.previous|to_fala_page_url(current_url) %}
                 <li class="moj-pagination__item  moj-pagination__item--prev" style="float:left;">

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -156,7 +156,7 @@
                   {% if item.location.type != 'Office' %}
                     <div class="org-type">{{ item.location.type|replace('Office', '') }}</div>
                   {% endif %}
-                  <p class="govuk-body-s org-address">
+                  <p class="govuk-body-s govuk-!-margin-top-0" style="padding-right:88px;">
                     <span class="govuk-visually-hidden">{{ _('Address') }}:</span>
                     <span class="adr">
                       <span class="street-address">{{ item.location.address }}</span>
@@ -177,12 +177,11 @@
                     </p>
                   {% endif %}
                   {% if item.categories|length %}
-                    <h4 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-bottom-2">{{ _('Categories of law') }}</h4>
+                    <h4 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-bottom-2">{{ _('Categories of law covered') }}</h4>
                     <ul class="govuk-list govuk-list--bullet govuk-!-font-size-14" role="list">
                       {% for cat in item.categories %}
                         {% if cat %}
                           <li class="govuk-!-margin-0" role="listitem">{{ cat }}</li>
-                          {%- if not loop.last %},{% endif %}
                         {% endif %}
                       {% endfor %}
                     </ul>

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -146,7 +146,7 @@
                     <span class="fn org">{{ item.organisation.name }}</span>
                   </h3>
                   {% if item.distance %}
-                    <div class="govuk-body-s distance">
+                    <div class="distance">
                       <span class="govuk-visually-hidden">{{ _('Distance') }}</span>
                       {% trans miles=item.distance|round(2) %}{{ miles }} miles{% endtrans %}
                     </div>

--- a/fala/templates/adviser/_results.html
+++ b/fala/templates/adviser/_results.html
@@ -194,22 +194,23 @@
 
         {% if data.previous or data.next %}
           <nav class="search-results-pagination">
-            <ul>
+            <p class="govuk-visually-hidden" aria-labelledby="pagination-label">{{ _('Results navigation') }}</p>
+            <ul class="moj-pagination__list">
               {% if data.previous %}
                 {% set prev_page = data.previous|to_fala_page_url(current_url) %}
-                <li class="results-nav results-nav-prev">
-                  <a class="govuk-link" href="{{ prev_page|replace('organisation_', '') }}"
+                <li class="moj-pagination__item  moj-pagination__item--prev">
+                  <a class="moj-pagination__link" href="{{ prev_page|replace('organisation_', '') }}"
                      data-page="{{ prev_page|query_to_dict('page')|first }}">
-                    {{ _('Previous') }}
+                    {{ _('Previous') }}<span class="govuk-visually-hidden"> {{ _('set of pages') }}</span>
                   </a>
                 </li>
               {% endif %}
               {% if data.next %}
                 {% set next_page = data.next|to_fala_page_url(current_url) %}
-                <li class="results-nav results-nav-next">
-                  <a class="govuk-link" href="{{ next_page|replace('organisation_', '') }}"
+                <li class="moj-pagination__item  moj-pagination__item--next">
+                  <a class="moj-pagination__link" href="{{ next_page|replace('organisation_', '') }}"
                      data-page="{{ next_page|query_to_dict('page')|first }}">
-                    {{ _('Next') }}
+                    {{ _('Next') }}<span class="govuk-visually-hidden"> {{ _('set of pages') }}</span>
                   </a>
                 </li>
               {% endif %}


### PR DESCRIPTION
## What does this pull request do?

- Changes the focus colour to the new yellow for links on the Google map, including:
- - the full-screen button;
- - the zoom buttons;
- - the terms and conditions link.
- Changes the colours of the active state in the results panel.
- Changes the tag to GDS colours.
- Changes the list of legal area to a bulleted list.
- Changes the distance to GDS black.
- Removed the superfluous focus colour state for the whole div.
- Changes the next and previous navigation controls consistent with the MoJ Design System

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
