### PR TITLE
LGA-1035 Error message style

### DIFF
--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -30,7 +30,7 @@ class AdviserSearchForm(forms.Form):
     postcode = forms.CharField(
         label=_("Enter postcode, town or city"),
         max_length=30,
-        help_text=_("For example, SW1H 9AJ"),
+        help_text=_("For example, <span class='notranslate'>SW1H 9AJ</span>"),
         required=False,
         widget=FalaTextInput(attrs={"class": "govuk-input govuk-!-width-one-third"}),
     )
@@ -63,7 +63,7 @@ class AdviserSearchForm(forms.Form):
     def clean(self):
         data = self.cleaned_data
         if not data.get("postcode") and not data.get("name"):
-            raise forms.ValidationError(_("Please enter postcode or organisation name"))
+            raise forms.ValidationError(_("Enter a postcode or an organisation name"))
         return data
 
     def search(self):

--- a/fala/templates/adviser/search.html
+++ b/fala/templates/adviser/search.html
@@ -8,15 +8,14 @@
 {% import "macros/forms.html" as Form %}
 
 {% block search_form %}
-  {% if form.errors and form.errors['__all__'] %}
-    {% call Element.alert('error', title='Form errors') %}
-      {% for k, error in form.errors.items() %}
-        {{ error }}
-      {% endfor %}
-    {% endcall %}
-  {% endif %}
   <form action="" style="margin-top:1em" novalidate>
-    <div class="govuk-form-group">
+    <div 
+      class="govuk-form-group
+        {% if (form.postcode and form.postcode.errors) or (form.name and form.name.errors) %}
+          govuk-form-group--error
+        {% endif %}
+        "
+      id="fala_questions">
       {% call Form.group(form.postcode, 'form-group-plain', hide_optional=True) %}
       {% endcall %}
       {% call Form.group(form.name, 'form-group-plain', hide_optional=True) %}

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -54,7 +54,30 @@
 
 {% block content %}
   <div class="govuk-grid-column-full">
-    <div id="google_translate_element"></div>
+    <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+
+    {% if form.errors and form.errors['__all__'] %}
+      {% call Element.error('error', title='There is a problem') %}
+        {% for k, error in form.errors.items() %}
+          {{ error | 
+          replace("errorlist nonfield","govuk-list govuk-error-summary__list") | 
+          replace("Enter a postcode or an organisation name",'<a href="#id_postcode" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_postcode&quot;);return false;" >Enter a postcode or an organisation name</a>') | 
+          safe }}
+        {% endfor %}
+      {% endcall %}
+    {% elif (form.postcode and form.postcode.errors) or (form.name and form.name.errors) %}
+      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+        <h2 class="govuk-error-summary__title" id="error-summary-title">
+          There is a problem
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            {{ Form.render_field_errors_for_summary(form.postcode) }}
+            {{ Form.render_field_errors_for_summary(form.name) }}
+          </ul>
+        </div>
+      </div>
+    {% endif %}
     <h1 class="govuk-heading-xl govuk-!-margin-top-7">
       Find a legal aid adviser <br />
       <span class="govuk-!-font-weight-regular govuk-!-font-size-36">or family mediator</span>
@@ -131,4 +154,10 @@
     }
   </script>
   <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+  <script>
+    function errorScroll(s,f) {
+      document.getElementById(s).scrollIntoView();
+      document.getElementById(f).focus();
+    }
+  </script>
 {% endblock %}

--- a/fala/templates/macros/element.html
+++ b/fala/templates/macros/element.html
@@ -25,3 +25,16 @@
     </div>
   </div>
 {% endmacro %}
+
+{% macro error(type='error', icon=None, title=None) %}
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    {% if title %}
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        {{ _(title) }}
+      </h2>
+    {% endif %}
+    <div class="govuk-error-summary__body">
+      {{ caller() }}
+    </div>
+  </div>
+{% endmacro %}

--- a/fala/templates/macros/forms.html
+++ b/fala/templates/macros/forms.html
@@ -89,7 +89,7 @@
 #}
 {% macro render_field_description(field) %}
   {% if field and field.help_text %}
-    <span class="govuk-hint" id="field-description-{{ field.id }}">
+    <span class="govuk-hint" id="field-description-{{ field.name }}">
       {{- field.help_text | safe -}}
     </span>
   {%- endif -%}

--- a/fala/templates/macros/forms.html
+++ b/fala/templates/macros/forms.html
@@ -109,7 +109,7 @@
     <div class="form-row govuk-error-message">
       {% for error in errors %}
         {% if error is string or error == error|string %}
-          {{error}}
+          <span class="govuk-visually-hidden">Error:</span> {{error}}
         {% else %}
           {% for line in error %}
             <span class="govuk-visually-hidden">Error:</span> {{ line }}

--- a/fala/templates/macros/forms.html
+++ b/fala/templates/macros/forms.html
@@ -32,11 +32,11 @@
 
     {{ render_field_label(field, kwargs.hide_label, kwargs.hide_optional) }}
 
+    {{ render_field_description(field) }}
+
     {% if field and (field.errors and controlled_by and not controlled_by.errors or field.errors and not controlled_by) %}
       {{ render_field_errors(field) }}
     {% endif %}
-
-    {{ render_field_description(field) }}
 
     {% if use_row and (field or caller) %}
       <div class="form-row {{ kwargs.row_class or '' }}">
@@ -90,7 +90,7 @@
 {% macro render_field_description(field) %}
   {% if field and field.help_text %}
     <span class="govuk-hint" id="field-description-{{ field.id }}">
-      {{- field.help_text -}}
+      {{- field.help_text | safe -}}
     </span>
   {%- endif -%}
 {% endmacro %}
@@ -112,11 +112,30 @@
           {{error}}
         {% else %}
           {% for line in error %}
-            <p>{{line}}</p>
+            <span class="govuk-visually-hidden">Error:</span> {{ line }}
           {% endfor %}
         {% endif %}
       {% endfor %}
     </div>
+  {% endif %}
+{% endmacro %}
+
+{% macro render_field_errors_for_summary(field, id) %}
+  {% if field and field.errors %}
+    {% set errors = field.errors.values() if field.errors is mapping else field.errors %}
+    {% for error in errors %}
+      {% if error is string or error == error|string %}
+        <li>
+          <a href="#id_{{ field.name }}" onclick='errorScroll("fala_questions","id_{{ field.name }}");return false;'>{{ error }}</a>
+        </li>
+      {% else %}
+        {% for line in error %}
+           <li>
+            <a href="#id_{{ field.name }}" onclick='errorScroll("fala_questions","id_{{ field.name }}");return false;'>{{ line }}</a>
+          </li>
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
   {% endif %}
 {% endmacro %}
 
@@ -156,8 +175,8 @@
       </legend>
     {% endif %}
 
-    {{ render_field_errors(field) }}
     {{ render_field_description(field) }}
+    {{ render_field_errors(field) }}
 
     {% if field or caller %}
       <div class="form-row {{ kwargs.row_class }}">


### PR DESCRIPTION
## What does this pull request do?

- Moved the error summary to the top of the page (just below the Google translate control)
- Added a margin to the Google translate control to separate it from the error box.
- New JS function for error finding.
- Added in error summary for field errors.
- Field error location swapped with hint text.

## Any other changes that would benefit highlighting?

- Marked the postcode in the hint text as no-translate.  
(Google translate was "translating" SW1H 9JA to 9JA SW1H)
- Marked the hint text as `| safe` for the above

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
