### PR TITLE
LGA-1041 New Cookie Banner and GA by consent.  

### DIFF
--- a/fala/assets-src/sass/main.scss
+++ b/fala/assets-src/sass/main.scss
@@ -100,3 +100,19 @@ p.govuk-body-l:last-child {
 .gds-header__error {
   border-bottom: 10px solid $govuk-error-colour;
 }
+
+.laa-cookie-banner {
+  background: govuk-colour("white");
+  display: none;
+
+  &.laa-cookies-accepted {
+    display:none;
+  }
+  &.laa-cookies-rejected {
+    display:none;
+  }
+}
+
+.js-enabled .laa-cookie-banner {
+  display:block;
+}

--- a/fala/assets-src/sass/main.scss
+++ b/fala/assets-src/sass/main.scss
@@ -116,3 +116,11 @@ p.govuk-body-l:last-child {
     display:none;
   }
 }
+
+.laa-hide-if-no-js {
+  display:none;
+}
+
+.js-enabled .laa-hide-if-no-js {
+  display:initial;
+}

--- a/fala/assets-src/sass/main.scss
+++ b/fala/assets-src/sass/main.scss
@@ -105,14 +105,15 @@ p.govuk-body-l:last-child {
   background: govuk-colour("white");
   display: none;
 
+}
+
+.js-enabled .laa-cookie-banner {
+  display:block;
+
   &.laa-cookies-accepted {
     display:none;
   }
   &.laa-cookies-rejected {
     display:none;
   }
-}
-
-.js-enabled .laa-cookie-banner {
-  display:block;
 }

--- a/fala/assets-src/sass/main.scss
+++ b/fala/assets-src/sass/main.scss
@@ -104,7 +104,6 @@ p.govuk-body-l:last-child {
 .laa-cookie-banner {
   background: govuk-colour("white");
   display: none;
-
 }
 
 .js-enabled .laa-cookie-banner {

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -122,20 +122,18 @@
 
 {% block before_main_js %}
   {{ super() }}
-  {% if GA_ID %}
+  {% if GA_ID and request.COOKIES.get('cookiePermission') == 'Allowed' %}
     <script>
       ga('create', '{{ GA_ID }}', 'auto');
-      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');")
       ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));
-      console.log("cookie code: ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));")
       ga('send', 'pageview');
-      console.log("cookie code: ga('send', 'pageview');")
     </script>
-  {% else %}
+  {% endif %}
+  {% if request.COOKIES.get('cookiePermission') == 'Allowed' %}
     <script>
-      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');")
-      console.log("cookie code: ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));")
-      console.log("cookie code: ga('send', 'pageview');")
+      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');");
+      console.log("cookie code: ga('set', 'location', " + window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted') + ");");
+      console.log("cookie code: ga('send', 'pageview');");
     </script>
   {% endif %}
   <script src="//maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}"></script>
@@ -147,17 +145,16 @@
 {% endblock %}
 
 {% block after_main_js %}
-  {% if GA_ID %}
+  {% if GA_ID and request.COOKIES.get('cookiePermission') == 'Allowed' %}
     <script>
       ga('create', '{{ GA_ID }}', 'auto');
-      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');")
       ga('send', 'pageview');
-      console.log("cookie code: ga('send', 'pageview');")
     </script>
-  {% else %}
+  {% endif %}
+  {% if request.COOKIES.get('cookiePermission') == 'Allowed' %}
     <script>
-      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');")
-      console.log("cookie code: ga('send', 'pageview');")
+      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');");
+      console.log("cookie code: ga('send', 'pageview');");
     </script>
   {% endif %}
   <script>

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -125,8 +125,11 @@
   {% if GA_ID %}
     <script>
       ga('create', '{{ GA_ID }}', 'auto');
+      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');")
       ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));
+      console.log("cookie code: ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));")
       ga('send', 'pageview');
+      console.log("cookie code: ga('send', 'pageview');")
     </script>
   {% endif %}
   <script src="//maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}"></script>
@@ -141,7 +144,9 @@
   {% if GA_ID %}
     <script>
       ga('create', '{{ GA_ID }}', 'auto');
+      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');")
       ga('send', 'pageview');
+      console.log("cookie code: ga('send', 'pageview');")
     </script>
   {% endif %}
   <script>

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -131,6 +131,12 @@
       ga('send', 'pageview');
       console.log("cookie code: ga('send', 'pageview');")
     </script>
+  {% else %}
+    <script>
+      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');")
+      console.log("cookie code: ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));")
+      console.log("cookie code: ga('send', 'pageview');")
+    </script>
   {% endif %}
   <script src="//maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}"></script>
   <script>
@@ -146,6 +152,11 @@
       ga('create', '{{ GA_ID }}', 'auto');
       console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');")
       ga('send', 'pageview');
+      console.log("cookie code: ga('send', 'pageview');")
+    </script>
+  {% else %}
+    <script>
+      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');")
       console.log("cookie code: ga('send', 'pageview');")
     </script>
   {% endif %}

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -124,12 +124,16 @@
   {{ super() }}
   <script>
     function performGoogleAnalyticalTasks() {
-      ga('create', '{{ GA_ID }}', 'auto');
-      ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));
-      ga('send', 'pageview');
+      {% if GA_ID %}
+        ga('create', '{{ GA_ID }}', 'auto');
+        ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));
+        ga('send', 'pageview');
+      {% else %}
+        console.log("Analyzed - no GA ID");
+      {% endif %}
     }
   </script>
-  {% if GA_ID and request.COOKIES.get('cookiePermission') == 'Allowed' %}
+  {% if request.COOKIES.get('cookiePermission') == 'Allowed' %}
     <script>
       performGoogleAnalyticalTasks()
     </script>

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -102,11 +102,18 @@
 {% endblock %}
 
 {% block support_links_items %}
-  <li class="govuk-footer__inline-list-item">
-    <a class="govuk-footer__link" href="https://www.gov.uk/help/cookies">
+  <li class="govuk-footer__inline-list-item laa-hide-if-no-js">
+    <a id="cookieReview" class="govuk-footer__link" href="#top">
       Cookies
     </a>
   </li>
+  <noscript>
+    <li class="govuk-footer__inline-list-item">
+      <a class="govuk-footer__link" href="https://www.gov.uk/help/cookies">
+        Cookies
+      </a>
+    </li>
+  </noscript>
   <li class="govuk-footer__inline-list-item">
     <a class="govuk-footer__link"  href="https://www.gov.uk/government/organisations/legal-aid-agency">
       Legal Aid Agency

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -122,18 +122,16 @@
 
 {% block before_main_js %}
   {{ super() }}
-  {% if GA_ID and request.COOKIES.get('cookiePermission') == 'Allowed' %}
-    <script>
+  <script>
+    function performGoogleAnalyticalTasks() {
       ga('create', '{{ GA_ID }}', 'auto');
       ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));
       ga('send', 'pageview');
-    </script>
-  {% endif %}
-  {% if request.COOKIES.get('cookiePermission') == 'Allowed' %}
+    }
+  </script>
+  {% if GA_ID and request.COOKIES.get('cookiePermission') == 'Allowed' %}
     <script>
-      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');");
-      console.log("cookie code: ga('set', 'location', " + window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted') + ");");
-      console.log("cookie code: ga('send', 'pageview');");
+      performGoogleAnalyticalTasks()
     </script>
   {% endif %}
   <script src="//maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}"></script>
@@ -145,18 +143,6 @@
 {% endblock %}
 
 {% block after_main_js %}
-  {% if GA_ID and request.COOKIES.get('cookiePermission') == 'Allowed' %}
-    <script>
-      ga('create', '{{ GA_ID }}', 'auto');
-      ga('send', 'pageview');
-    </script>
-  {% endif %}
-  {% if request.COOKIES.get('cookiePermission') == 'Allowed' %}
-    <script>
-      console.log("cookie code: ga('create', '{{ GA_ID }}', 'auto');");
-      console.log("cookie code: ga('send', 'pageview');");
-    </script>
-  {% endif %}
   <script>
     function googleTranslateElementInit() {
       new google.translate.TranslateElement(

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -4,14 +4,6 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <title>{% block page_title %}GOV.UK - The best place to find government services and information{% endblock %}</title>
     <script>(function(d){d.className=d.className.replace(/\bno-js\b/,'js-enabled')})(document.documentElement);</script>
-    <script>
-      function cookiesAccepted() {
-        $(".laa-cookie-banner").addClass("laa-cookies-accepted");
-      }
-      function cookiesRejected() {
-        $(".laa-cookie-banner").addClass("laa-cookies-rejected");
-      }
-    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% block stylesheets %}{% endblock %}
     {% block head %}{% endblock %}
@@ -31,10 +23,10 @@
                   {% trans %}We use this information to make the website work as well as possible and improve government services.{% endtrans %}
                 </p>
               </div>
-              <button onclick="cookiesAccepted()" class="no-js-hide-inline-block govuk-button govuk-!-margin-bottom-4 govuk-!-margin-right-7" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">
+              <button id="cookieAccept" class="no-js-hide-inline-block govuk-button govuk-!-margin-bottom-4 govuk-!-margin-right-7" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">
                 {% trans %}Accept cookies{% endtrans %}
               </button>
-              <button onclick="cookiesRejected()" class="govuk-button govuk-button--secondary" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/cookie-settings">
+              <button id="cookieReject" class="govuk-button govuk-button--secondary" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/cookie-settings">
                 {% trans %}Reject cookies{% endtrans %}
               </button>
             </div>
@@ -102,6 +94,16 @@
     {% block before_main_js %}{% endblock %}
     {% block main_js %}{% endblock %}
     {% block after_main_js %}{% endblock %}
-    <script src="{{ static('javascripts/vendor/jquery/jquery-1.11.0.min.js') }}" type="text/javascript"></script>
+    <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.4.1.min.js" type="text/javascript"></script>
+    <script>
+      $(function() {
+        $("#cookieAccept").click(function() {
+          $(".laa-cookie-banner").addClass("laa-cookies-accepted");
+        });
+        $("#cookieAReject").click(function() {
+          $(".laa-cookie-banner").addClass("laa-cookies-rejected");
+        });
+      });
+    </script>
   </body>
 </html>

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -121,6 +121,7 @@
         $("#cookieAccept").click(function() {
           setCookie("cookiePermission", "Allowed", 30);
           $(".laa-cookie-banner").addClass("laa-cookies-accepted");
+          performGoogleAnalyticalTasks();
         });
         $("#cookieReject").click(function() {
           eraseCookie("cookiePermission");

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -11,11 +11,33 @@
   <body class="govuk-template__body ">
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <header class="govuk-header " role="banner" data-module="govuk-header">
-      <div id="global-cookie-message">
-        <div class="container">
-          <p class="govuk-body-s">GOV.UK uses cookies to make the site simpler. <a class="govuk-link" href="https://www.gov.uk/help/cookies">Find out more about
-            cookies.</a></p>
+      <div class="gem-c-cookie-banner__wrapper govuk-width-container govuk-!-padding-top-3">
+        <div class="govuk-grid-row">
+          <div class=" govuk-grid-column-three-quarters">
+            <div class="gem-c-cookie-banner__message">
+              <span class="govuk-heading-m">{% trans %}Cookies on Check if you can get Legal Aid{% endtrans %}</span>
+              <p class="govuk-body">
+                {% set cookie_info_url = '/cookies' %}
+                {% trans %}We use <a class="govuk-link" href="{{ cookie_info_url }}">cookies to collect information</a> about how you use GOV.UK.{% endtrans %}
+                {% trans %}We use this information to make the website work as well as possible and improve government services.{% endtrans %}
+              </p>
+            </div>
+            <button class="no-js-hide-inline-block gem-c-button govuk-button gem-c-button--inline govuk-!-margin-bottom-4 govuk-!-margin-right-7" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">
+              {% trans %}Accept all cookies{% endtrans %}
+            </button>
+            <a class="gem-c-button govuk-button gem-c-button--inline govuk-button--secondary" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/cookie-settings">
+              {% trans %}Set cookie preferences{% endtrans %}
+            </a>
+          </div>
         </div>
+      </div>
+
+      <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1">
+        <p class="govuk-body govuk-!-margin-top-2 gem-c-cookie-banner__confirmation-message">
+          {% set cookie_settings_url = url_for('base.cookie_settings') %}
+          {% trans %}You’ve accepted all cookies. You can <a class="govuk-link" href="{{ cookie_settings_url }}" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.{% endtrans %}
+        </p>
+        <button class="govuk-link govuk-!-margin-top-2 gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">{% trans %}Hide{% endtrans %}</button>
       </div>
       <div class="govuk-header__container govuk-width-container {% if error is defined %}gds-header__error{% endif %}">
         <div class="govuk-header__logo">

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -11,7 +11,12 @@
   <body class="govuk-template__body ">
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <header class="govuk-header " role="banner" data-module="govuk-header">
-      <div id="cookie-message" class="laa-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner">
+      <div id="cookie-message" class="
+        laa-cookie-banner
+        {% if request.COOKIES.get('cookiePermission') == 'Allowed' %}
+          laa-cookies-accepted
+        {% endif %}
+        " data-module="cookie-banner" role="region" aria-label="cookie banner">
         <div class="govuk-width-container govuk-!-padding-top-3">
           <div class="govuk-grid-row">
             <div class=" govuk-grid-column-three-quarters">
@@ -96,11 +101,32 @@
     {% block after_main_js %}{% endblock %}
     <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.4.1.min.js" type="text/javascript"></script>
     <script>
+      function setCookie(key, value, expiry) {
+        var expires = new Date();
+        expires.setTime(expires.getTime() + (expiry * 24 * 60 * 60 * 1000));
+        document.cookie = key + '=' + value + ';expires=' + expires.toUTCString();
+      }
+
+      function getCookie(key) {
+        var keyValue = document.cookie.match('(^|;) ?' + key + '=([^;]*)(;|$)');
+        return keyValue ? keyValue[2] : null;
+      }
+
+      function eraseCookie(key) {
+        var keyValue = getCookie(key);
+        setCookie(key, keyValue, '-1');
+      }
+
       $(function() {
+      //  if (getCookie("cookiePermission") == "Allowed") {
+      //    $(".laa-cookie-banner").addClass("laa-cookies-accepted");
+      //  }
         $("#cookieAccept").click(function() {
+          setCookie("cookiePermission", "Allowed", 30);
           $(".laa-cookie-banner").addClass("laa-cookies-accepted");
         });
         $("#cookieReject").click(function() {
+          eraseCookie("cookiePermission");
           $(".laa-cookie-banner").addClass("laa-cookies-rejected");
         });
       });

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -118,9 +118,6 @@
       }
 
       $(function() {
-      //  if (getCookie("cookiePermission") == "Allowed") {
-      //    $(".laa-cookie-banner").addClass("laa-cookies-accepted");
-      //  }
         $("#cookieAccept").click(function() {
           setCookie("cookiePermission", "Allowed", 30);
           $(".laa-cookie-banner").addClass("laa-cookies-accepted");

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -127,6 +127,18 @@
           eraseCookie("cookiePermission");
           $(".laa-cookie-banner").addClass("laa-cookies-rejected");
         });
+        $("#cookieReview").click(function() {
+          $(".laa-cookie-banner").removeClass("laa-cookies-accepted").removeClass("laa-cookies-rejected");
+          $("html, body").animate(
+            { scrollTop: 0 }, 
+            "slow", 
+            "swing", 
+            function(){
+              $("#cookieAccept").focus();
+            }
+          );
+          return false;
+        });
       });
     </script>
   </body>

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -11,7 +11,7 @@
   <body class="govuk-template__body ">
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <header class="govuk-header " role="banner" data-module="govuk-header">
-      <div id="cookie-message" class="laa-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner" style="display: block;">
+      <div id="cookie-message" class="laa-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner">
         <div class="govuk-width-container govuk-!-padding-top-3">
           <div class="govuk-grid-row">
             <div class=" govuk-grid-column-three-quarters">
@@ -19,7 +19,7 @@
                 <span class="govuk-heading-m">{% trans %}Cookies on Check if you can get Legal Aid{% endtrans %}</span>
                 <p class="govuk-body">
                   {% set cookie_info_url = '/cookies' %}
-                  {% trans %}We use <a class="govuk-link" href="{{ cookie_info_url }}">cookies to collect information</a> about how you use GOV.UK.{% endtrans %}
+                  {% trans %}We use cookies to collect information about how you use GOV.UK.{% endtrans %}
                   {% trans %}We use this information to make the website work as well as possible and improve government services.{% endtrans %}
                 </p>
               </div>
@@ -100,7 +100,7 @@
         $("#cookieAccept").click(function() {
           $(".laa-cookie-banner").addClass("laa-cookies-accepted");
         });
-        $("#cookieAReject").click(function() {
+        $("#cookieReject").click(function() {
           $(".laa-cookie-banner").addClass("laa-cookies-rejected");
         });
       });

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -4,6 +4,14 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <title>{% block page_title %}GOV.UK - The best place to find government services and information{% endblock %}</title>
     <script>(function(d){d.className=d.className.replace(/\bno-js\b/,'js-enabled')})(document.documentElement);</script>
+    <script>
+      function cookiesAccepted() {
+        $(".laa-cookie-banner").addClass("laa-cookies-accepted");
+      }
+      function cookiesRejected() {
+        $(".laa-cookie-banner").addClass("laa-cookies-rejected");
+      }
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% block stylesheets %}{% endblock %}
     {% block head %}{% endblock %}
@@ -11,34 +19,29 @@
   <body class="govuk-template__body ">
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <header class="govuk-header " role="banner" data-module="govuk-header">
-      <div class="gem-c-cookie-banner__wrapper govuk-width-container govuk-!-padding-top-3">
-        <div class="govuk-grid-row">
-          <div class=" govuk-grid-column-three-quarters">
-            <div class="gem-c-cookie-banner__message">
-              <span class="govuk-heading-m">{% trans %}Cookies on Check if you can get Legal Aid{% endtrans %}</span>
-              <p class="govuk-body">
-                {% set cookie_info_url = '/cookies' %}
-                {% trans %}We use <a class="govuk-link" href="{{ cookie_info_url }}">cookies to collect information</a> about how you use GOV.UK.{% endtrans %}
-                {% trans %}We use this information to make the website work as well as possible and improve government services.{% endtrans %}
-              </p>
+      <div id="cookie-message" class="laa-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner" style="display: block;">
+        <div class="govuk-width-container govuk-!-padding-top-3">
+          <div class="govuk-grid-row">
+            <div class=" govuk-grid-column-three-quarters">
+              <div>
+                <span class="govuk-heading-m">{% trans %}Cookies on Check if you can get Legal Aid{% endtrans %}</span>
+                <p class="govuk-body">
+                  {% set cookie_info_url = '/cookies' %}
+                  {% trans %}We use <a class="govuk-link" href="{{ cookie_info_url }}">cookies to collect information</a> about how you use GOV.UK.{% endtrans %}
+                  {% trans %}We use this information to make the website work as well as possible and improve government services.{% endtrans %}
+                </p>
+              </div>
+              <button onclick="cookiesAccepted()" class="no-js-hide-inline-block govuk-button govuk-!-margin-bottom-4 govuk-!-margin-right-7" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">
+                {% trans %}Accept cookies{% endtrans %}
+              </button>
+              <button onclick="cookiesRejected()" class="govuk-button govuk-button--secondary" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/cookie-settings">
+                {% trans %}Reject cookies{% endtrans %}
+              </button>
             </div>
-            <button class="no-js-hide-inline-block gem-c-button govuk-button gem-c-button--inline govuk-!-margin-bottom-4 govuk-!-margin-right-7" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">
-              {% trans %}Accept all cookies{% endtrans %}
-            </button>
-            <a class="gem-c-button govuk-button gem-c-button--inline govuk-button--secondary" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/cookie-settings">
-              {% trans %}Set cookie preferences{% endtrans %}
-            </a>
           </div>
         </div>
       </div>
 
-      <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1">
-        <p class="govuk-body govuk-!-margin-top-2 gem-c-cookie-banner__confirmation-message">
-          {% set cookie_settings_url = url_for('base.cookie_settings') %}
-          {% trans %}You’ve accepted all cookies. You can <a class="govuk-link" href="{{ cookie_settings_url }}" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.{% endtrans %}
-        </p>
-        <button class="govuk-link govuk-!-margin-top-2 gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">{% trans %}Hide{% endtrans %}</button>
-      </div>
       <div class="govuk-header__container govuk-width-container {% if error is defined %}gds-header__error{% endif %}">
         <div class="govuk-header__logo">
           <a href="#" class="govuk-header__link govuk-header__link--homepage">

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -102,5 +102,6 @@
     {% block before_main_js %}{% endblock %}
     {% block main_js %}{% endblock %}
     {% block after_main_js %}{% endblock %}
+    <script src="{{ static('javascripts/vendor/jquery/jquery-1.11.0.min.js') }}" type="text/javascript"></script>
   </body>
 </html>


### PR DESCRIPTION
## What does this pull request do?

Replaces defunct cookie banner with new banner with accept and reject options.
Sets a cookie for 1 month if approved.  
Moves GA startup functions into new function.
If no GA ID - this function only prints something to the console.
Runs said function on page load only if cookies are approved.
Runs said function when cookies approved.
Changes (JS enabled) cookie link at the bottom to re-shew the cookie banner, set focus and scroll to it.  

## Any other changes that would benefit highlighting?

Removed duplicated GA functions

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
