### PR TITLE
LGA-1213 Circle CI approval stage moved earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,10 +155,9 @@ workflows:
           context: laa-fala-live-1
       - staging_deploy_approval:
           type: approval
-          requires:
-            - build
       - staging_deploy:
           requires:
+            - build
             - staging_deploy_approval
           context: laa-fala-live-1
       - production_deploy_approval:


### PR DESCRIPTION
## What does this pull request do?

Rearranges Circle CI flow so approval for staging deploy can be done immediately.  
It also makes staging deploy require a successful build as well as the approval.
(Essentially, the requirement for Build is moved from the approval to the actual staging deploy.)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
