### PR TITLE
LGA-1191 error styling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,10 +155,9 @@ workflows:
           context: laa-fala-live-1
       - staging_deploy_approval:
           type: approval
-          requires:
-            - build
       - staging_deploy:
           requires:
+            - build
             - staging_deploy_approval
           context: laa-fala-live-1
       - production_deploy_approval:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,9 +155,10 @@ workflows:
           context: laa-fala-live-1
       - staging_deploy_approval:
           type: approval
-      - staging_deploy:
           requires:
             - build
+      - staging_deploy:
+          requires:
             - staging_deploy_approval
           context: laa-fala-live-1
       - production_deploy_approval:

--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -25,8 +25,6 @@ class FalaTextInput(forms.TextInput):
 
 class AdviserSearchForm(forms.Form):
 
-    error_css_class = "govuk-input--error"
-
     page = forms.IntegerField(required=False, widget=forms.HiddenInput())
 
     postcode = forms.CharField(

--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -17,13 +17,15 @@ ORGANISATION_TYPES_CHOICES = [
 
 class FalaTextInput(forms.TextInput):
     def __init__(self, attrs={}):
-        class_attr = " ".join([c for c in ["form-control", attrs.get("class")] if c])
+        class_attr = " ".join([c for c in ["govuk-input govuk-!-width-one-third", attrs.get("class")] if c])
         attrs.update({"class": class_attr})
 
         super(FalaTextInput, self).__init__(attrs)
 
 
 class AdviserSearchForm(forms.Form):
+
+    error_css_class = "govuk-input--error"
 
     page = forms.IntegerField(required=False, widget=forms.HiddenInput())
 
@@ -32,15 +34,10 @@ class AdviserSearchForm(forms.Form):
         max_length=30,
         help_text=_("For example, <span class='notranslate'>SW1H 9AJ</span>"),
         required=False,
-        widget=FalaTextInput(attrs={"class": "govuk-input govuk-!-width-one-third"}),
+        widget=FalaTextInput(),
     )
 
-    name = forms.CharField(
-        label=_("Organisation name"),
-        max_length=100,
-        required=False,
-        widget=FalaTextInput(attrs={"class": "govuk-input govuk-!-width-one-third"}),
-    )
+    name = forms.CharField(label=_("Organisation name"), max_length=100, required=False, widget=FalaTextInput(),)
 
     type = forms.MultipleChoiceField(
         label=_("Organisation type"),

--- a/fala/templates/adviser/search.html
+++ b/fala/templates/adviser/search.html
@@ -16,10 +16,28 @@
         {% endif %}
         "
       id="fala_questions">
-      {% call Form.group(form.postcode, 'form-group-plain', hide_optional=True) %}
-      {% endcall %}
-      {% call Form.group(form.name, 'form-group-plain', hide_optional=True) %}
-      {% endcall %}
+
+      {% set errorMessage = {'err': ""} %}
+
+      {% if form.errors and form.errors['__all__'] %}
+        {% call Element.errorText() %}
+          {% for k, error in form.errors.items() %}
+            {% if errorMessage.update({'err': error | striptags}) %}{% endif %}
+          {% endfor %}
+        {% endcall %}
+      {% endif %}
+
+      {% if (form.errors and form.errors['__all__']) %}
+        {% call Form.group(form.postcode, 'form-group-plain', {'class':'govuk-input--error'}, hide_optional=True, global_error=errorMessage.err) %}
+        {% endcall %}
+        {% call Form.group(form.name, 'form-group-plain', {'class':'govuk-input--error'}, hide_optional=True, max_length='100', global_error_hidden=errorMessage.err) %}
+        {% endcall %}
+      {% else %}
+        {% call Form.group(form.postcode, 'form-group-plain', hide_optional=True) %}
+        {% endcall %}
+        {% call Form.group(form.name, 'form-group-plain', hide_optional=True, max_length='100') %}
+        {% endcall %}
+      {% endif %}
     </div>
     <button type="submit" class="govuk-button" id="searchButton" name="search">Search</button>
 

--- a/fala/templates/adviser/search.html
+++ b/fala/templates/adviser/search.html
@@ -11,7 +11,7 @@
   <form action="" style="margin-top:1em" novalidate>
     <div 
       class="govuk-form-group
-        {% if (form.postcode and form.postcode.errors) or (form.name and form.name.errors) %}
+        {% if (form.postcode and form.postcode.errors) or (form.name and form.name.errors) or (form.errors and form.errors['__all__']) %}
           govuk-form-group--error
         {% endif %}
         "

--- a/fala/templates/adviser/search.html
+++ b/fala/templates/adviser/search.html
@@ -11,7 +11,7 @@
   <form action="" style="margin-top:1em" novalidate>
     <div 
       class="govuk-form-group
-        {% if (form.postcode and form.postcode.errors) or (form.name and form.name.errors) or (form.errors and form.errors['__all__']) %}
+        {% if (form.errors and form.errors['__all__']) %}
           govuk-form-group--error
         {% endif %}
         "
@@ -28,14 +28,14 @@
       {% endif %}
 
       {% if (form.errors and form.errors['__all__']) %}
-        {% call Form.group(form.postcode, 'form-group-plain', {'class':'govuk-input--error'}, hide_optional=True, global_error=errorMessage.err) %}
+        {% call Form.group(form.postcode, 'govuk-form-group', {'class':'govuk-input--error'}, hide_optional=True, global_error=errorMessage.err) %}
         {% endcall %}
-        {% call Form.group(form.name, 'form-group-plain', {'class':'govuk-input--error'}, hide_optional=True, max_length='100', global_error_hidden=errorMessage.err) %}
+        {% call Form.group(form.name, 'govuk-form-group', {'class':'govuk-input--error'}, hide_optional=True, max_length='100', global_error_hidden=errorMessage.err) %}
         {% endcall %}
       {% else %}
-        {% call Form.group(form.postcode, 'form-group-plain', hide_optional=True) %}
+        {% call Form.group(form.postcode, 'govuk-form-group', hide_optional=True) %}
         {% endcall %}
-        {% call Form.group(form.name, 'form-group-plain', hide_optional=True, max_length='100') %}
+        {% call Form.group(form.name, 'govuk-form-group', hide_optional=True, max_length='100') %}
         {% endcall %}
       {% endif %}
     </div>

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -62,9 +62,8 @@
           {% for k, error in form.errors.items() %}
             {% if "Enter a postcode or an organisation name" == error | striptags %}
               <a href="#id_postcode" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_postcode&quot;);return false;" >
-                Enter a postcode
-              </a>
-              or
+                Enter a postcode</a>
+              <b>or</b>
               <a href="#id_name" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_name&quot;);return false;" >
                 an organisation name
               </a>

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -58,13 +58,23 @@
 
     {% if form.errors and form.errors['__all__'] %}
       {% call Element.error('error', title='There is a problem') %}
-        {% for k, error in form.errors.items() %}
-          {{ error | 
-          replace("errorlist nonfield","govuk-list govuk-error-summary__list") | 
-          replace("<li>",'<a href="#id_postcode" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_postcode&quot;);return false;" >') | 
-          replace("</li>",'</a>') | 
-          safe }}
-        {% endfor %}
+        <ul class="govuk-list govuk-error-summary__list">
+          {% for k, error in form.errors.items() %}
+            {% if "Enter a postcode or an organisation name" == error | striptags %}
+              <a href="#id_postcode" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_postcode&quot;);return false;" >
+                Enter a postcode
+              </a>
+              or
+              <a href="#id_name" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_name&quot;);return false;" >
+                an organisation name
+              </a>
+            {% else %}
+              <a href="#id_postcode" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_postcode&quot;);return false;" >
+                {{ error | striptags }}
+              </a>
+            {% endif %}
+          {% endfor %}
+        </ul>
       {% endcall %}
     {% elif (form.postcode and form.postcode.errors) or (form.name and form.name.errors) %}
       <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -60,18 +60,20 @@
       {% call Element.error('error', title='There is a problem') %}
         <ul class="govuk-list govuk-error-summary__list">
           {% for k, error in form.errors.items() %}
-            {% if "Enter a postcode or an organisation name" == error | striptags %}
-              <a href="#id_postcode" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_postcode&quot;);return false;" >
-                Enter a postcode</a>
-              <b>or</b>
-              <a href="#id_name" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_name&quot;);return false;" >
-                an organisation name
-              </a>
-            {% else %}
-              <a href="#id_postcode" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_postcode&quot;);return false;" >
-                {{ error | striptags }}
-              </a>
-            {% endif %}
+            <li>
+              {% if "Enter a postcode or an organisation name" == error | striptags %}
+                <a href="#id_postcode" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_postcode&quot;);return false;" >
+                  Enter a postcode</a>
+                <b>or</b>
+                <a href="#id_name" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_name&quot;);return false;" >
+                  an organisation name
+                </a>
+              {% else %}
+                <a href="#id_postcode" onclick="errorScroll(&quot;fala_questions&quot;,&quot;id_postcode&quot;);return false;" >
+                  {{ error | striptags }}
+                </a>
+              {% endif %}
+            </li>
           {% endfor %}
         </ul>
       {% endcall %}

--- a/fala/templates/macros/element.html
+++ b/fala/templates/macros/element.html
@@ -38,3 +38,7 @@
     </div>
   </div>
 {% endmacro %}
+
+{% macro errorText() %}
+  {{ caller() }}
+{% endmacro %}

--- a/fala/templates/macros/forms.html
+++ b/fala/templates/macros/forms.html
@@ -31,7 +31,7 @@
   >
 
     {% if kwargs.global_error %}
-      <div aria-hidden="true" class="form-row govuk-error-message">
+      <div aria-hidden="true" class="govuk-!-margin-bottom-4 govuk-error-message">
         {{ kwargs.global_error }}
       </div>
     {% endif %}

--- a/fala/templates/macros/forms.html
+++ b/fala/templates/macros/forms.html
@@ -15,7 +15,7 @@
     - row_class <string> (default: '')
         Optional CSS class for `form-row` element
 #}
-{% macro group(field=None, class_='', field_attrs={}) %}
+{% macro group(field=None, class_='', field_attrs={'class':'govuk-input govuk-!-width-one-third govuk-input--error'}) %}
   {% set controlled_by = kwargs.controlled_by %}
   {% set control_value = kwargs.control_value if kwargs.control_value else '1' %}
   {% set use_row = kwargs.use_row if kwargs.use_row is defined else True %}
@@ -41,7 +41,11 @@
     {% if use_row and (field or caller) %}
       <div class="form-row {{ kwargs.row_class or '' }}">
         {% if field %}
-          {{ field }}
+          {% if (field.errors and controlled_by and not controlled_by.errors or field.errors and not controlled_by) %}
+            <input type="text" name="{{ field.name }}" value="{{ field.data }}" class="govuk-input govuk-input--error govuk-!-width-one-third" maxlength="30" id="id_{{ field.name }}">
+          {% else %}
+            <input type="text" name="{{ field.name }}" value="{{ field.data }}" class="govuk-input govuk-!-width-one-third" maxlength="30" id="id_{{ field.name }}">
+          {% endif %}
         {% endif %}
         {% if caller %}
           {{ caller() }}

--- a/fala/templates/macros/forms.html
+++ b/fala/templates/macros/forms.html
@@ -15,7 +15,7 @@
     - row_class <string> (default: '')
         Optional CSS class for `form-row` element
 #}
-{% macro group(field=None, class_='', field_attrs={'class':'govuk-input govuk-!-width-one-third govuk-input--error'}) %}
+{% macro group(field=None, class_='', field_attrs={}) %}
   {% set controlled_by = kwargs.controlled_by %}
   {% set control_value = kwargs.control_value if kwargs.control_value else '1' %}
   {% set use_row = kwargs.use_row if kwargs.use_row is defined else True %}
@@ -38,13 +38,21 @@
       {{ render_field_errors(field) }}
     {% endif %}
 
+    {% if kwargs.global_error %}
+      <div class="form-row govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span> {{ kwargs.global_error }}
+      </div>
+    {% elif kwargs.global_error_hidden %}
+      <span class="govuk-visually-hidden">Error: {{ kwargs.global_error_hidden }}</span>
+    {% endif %}
+    
     {% if use_row and (field or caller) %}
       <div class="form-row {{ kwargs.row_class or '' }}">
         {% if field %}
-          {% if (field.errors and controlled_by and not controlled_by.errors or field.errors and not controlled_by) %}
-            <input type="text" name="{{ field.name }}" value="{{ field.data }}" class="govuk-input govuk-input--error govuk-!-width-one-third" maxlength="30" id="id_{{ field.name }}">
+          {% if field.errors and controlled_by and not controlled_by.errors or field.errors and not controlled_by %}
+            <input type="text" name="{{ field.name }}" value="{{ field.data }}" class="govuk-input govuk-input--error govuk-!-width-one-third {{ field_attrs.class or '' }}" maxlength="{{ kwargs.max_length or '30' }}" id="id_{{ field.name }}">
           {% else %}
-            <input type="text" name="{{ field.name }}" value="{{ field.data }}" class="govuk-input govuk-!-width-one-third" maxlength="30" id="id_{{ field.name }}">
+            <input type="text" name="{{ field.name }}" value="{{ field.data }}" class="govuk-input govuk-!-width-one-third {{ field_attrs.class or '' }}" maxlength="{{ kwargs.max_length or '30' }}" id="id_{{ field.name }}">
           {% endif %}
         {% endif %}
         {% if caller %}

--- a/fala/templates/macros/forms.html
+++ b/fala/templates/macros/forms.html
@@ -23,7 +23,7 @@
 
   <div class="
       {{- group_class -}}
-      {%- if field and field.errors %} form-error{% endif -%}
+      {%- if field and field.errors %} govuk-form-group--error{% endif -%}
       {%- if controlled_by and control_value %} s-hidden{% endif -%}
     "
     {% if controlled_by %}data-controlled-by="{{ controlled_by.name }}" data-control-value="{{ control_value }}"{% endif %}

--- a/fala/templates/macros/forms.html
+++ b/fala/templates/macros/forms.html
@@ -30,6 +30,12 @@
     {% if field %}id="field-{{ field.html_name }}"{% endif %}
   >
 
+    {% if kwargs.global_error %}
+      <div aria-hidden="true" class="form-row govuk-error-message">
+        {{ kwargs.global_error }}
+      </div>
+    {% endif %}
+
     {{ render_field_label(field, kwargs.hide_label, kwargs.hide_optional) }}
 
     {{ render_field_description(field) }}
@@ -39,13 +45,11 @@
     {% endif %}
 
     {% if kwargs.global_error %}
-      <div class="form-row govuk-error-message">
-        <span class="govuk-visually-hidden">Error:</span> {{ kwargs.global_error }}
-      </div>
+      <span class="govuk-visually-hidden">Error: {{ kwargs.global_error }}</span>
     {% elif kwargs.global_error_hidden %}
       <span class="govuk-visually-hidden">Error: {{ kwargs.global_error_hidden }}</span>
     {% endif %}
-    
+
     {% if use_row and (field or caller) %}
       <div class="form-row {{ kwargs.row_class or '' }}">
         {% if field %}
@@ -85,7 +89,7 @@
       {% set label_text = field.label + ' <span class="form-optional">optional</span>' %}
     {% endif %}
 
-    <div class="form-group-label{{ (' sr-only' if hide_label else '') }}">
+    <div class="form-group-label{{ (' govuk-visually-hidden' if hide_label else '') }}">
       <label class="govuk-label" for="{{ field.id_for_label }}">{{ label_text|safe }}</label>
     </div>
   {% endif %}

--- a/fala/templates/macros/forms.html
+++ b/fala/templates/macros/forms.html
@@ -50,9 +50,9 @@
       <div class="form-row {{ kwargs.row_class or '' }}">
         {% if field %}
           {% if field.errors and controlled_by and not controlled_by.errors or field.errors and not controlled_by %}
-            <input type="text" name="{{ field.name }}" value="{{ field.data }}" class="govuk-input govuk-input--error govuk-!-width-one-third {{ field_attrs.class or '' }}" maxlength="{{ kwargs.max_length or '30' }}" id="id_{{ field.name }}">
+            <input type="text" name="{{ field.name }}" value="{{ field.data or '' }}" class="govuk-input govuk-input--error govuk-!-width-one-third {{ field_attrs.class or '' }}" maxlength="{{ kwargs.max_length or '30' }}" id="id_{{ field.name }}">
           {% else %}
-            <input type="text" name="{{ field.name }}" value="{{ field.data }}" class="govuk-input govuk-!-width-one-third {{ field_attrs.class or '' }}" maxlength="{{ kwargs.max_length or '30' }}" id="id_{{ field.name }}">
+            <input type="text" name="{{ field.name }}" value="{{ field.data or '' }}" class="govuk-input govuk-!-width-one-third {{ field_attrs.class or '' }}" maxlength="{{ kwargs.max_length or '30' }}" id="id_{{ field.name }}">
           {% endif %}
         {% endif %}
         {% if caller %}

--- a/fala/templates/macros/forms.html
+++ b/fala/templates/macros/forms.html
@@ -5,7 +5,7 @@
     - field <object> (optional)
         Form field
     - class_ <string> (default: '')
-        Additional CSS class (all form group wrappers get 'form-group' CSS class)
+        Additional CSS class (all form group wrappers get 'govuk-form-group' CSS class)
     - field_attrs <object> (default: {})
         Custom HTML attributes for field
     - controlled_by <string> (default: None)
@@ -19,7 +19,7 @@
   {% set controlled_by = kwargs.controlled_by %}
   {% set control_value = kwargs.control_value if kwargs.control_value else '1' %}
   {% set use_row = kwargs.use_row if kwargs.use_row is defined else True %}
-  {% set group_class = class_ if class_.startswith('form-group') else 'form-group %s' % class_ %}
+  {% set group_class = class_ if class_.startswith('govuk-form-group ') else 'govuk-form-group %s' % class_ %}
 
   <div class="
       {{- group_class -}}


### PR DESCRIPTION
## What does this pull request do?

- Added error highlighting for input boxes.
- Added error text for global errors (visible above postcode input and screen reader only above org input)
- Restricted red line for non-global errors to relevant field only.
- Error summary for no answer changed to link to both postcode and org boxes.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
