### PR TITLE
LGA-1426 - Sentry SDK

### DIFF
--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -15,9 +15,6 @@ class AdviserView(TemplateView):
         view_name = resolve(request.path_info).url_name
         current_url = reverse(view_name)
 
-        if "error" in request.GET.keys():
-            raise Exception
-
         context.update(
             {
                 "form": form,

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -15,6 +15,9 @@ class AdviserView(TemplateView):
         view_name = resolve(request.path_info).url_name
         current_url = reverse(view_name)
 
+        if "error" in request.GET.keys():
+            raise Exception
+
         context.update(
             {
                 "form": form,

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -3,6 +3,9 @@ import sys
 import os
 from os.path import join, abspath, dirname
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
 
 def here(*x):
     return join(abspath(dirname(__file__)), *x)
@@ -128,15 +131,14 @@ LOGGING = {
     "loggers": {"root": {"level": "DEBUG", "handlers": ["console"]}},
 }
 
-# RAVEN SENTRY CONFIG
+# SENTRY CONFIG
 if "SENTRY_DSN" in os.environ:
-    RAVEN_CONFIG = {"dsn": os.environ.get("SENTRY_DSN")}
-
-    INSTALLED_APPS += ("raven.contrib.django.raven_compat",)
-
-    MIDDLEWARE_CLASSES = (
-        "raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware",
-    ) + MIDDLEWARE_CLASSES
+    sentry_sdk.init(
+        dsn=os.environ.get("SENTRY_DSN"),
+        integrations=[DjangoIntegration()],
+        traces_sample_rate=1.0,
+        environment=os.environ.get("ENVIRONMENT", "unknown"),
+    )
 
 LAALAA_API_HOST = os.environ.get("LAALAA_API_HOST", None)
 

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -46,7 +46,7 @@ spec:
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
-              name: new-sentry
+              name: sentry
               key: dsn
         - name: SECRET_KEY
           valueFrom:

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -37,6 +37,8 @@ spec:
           value: AIzaSyC3yE4iqalLcys8ZbjdZAPjDpcYuwd2GME
         - name: LAALAA_API_HOST
           value: https://laa-legal-adviser-api-production.cloud-platform.service.justice.gov.uk
+        - name: ENVIRONMENT
+          value: staging
         - name: GA_ID
           value: "UA-37377084-6"
         - name: DJANGO_SETTINGS_MODULE
@@ -44,7 +46,7 @@ spec:
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
-              name: sentry
+              name: new-sentry
               key: dsn
         - name: SECRET_KEY
           valueFrom:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -37,10 +37,12 @@ spec:
           value: AIzaSyDdz1B1M2-2r0CQKJPscvmNEyxGwSZkXJk
         - name: LAALAA_API_HOST
           value: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+        - name: ENVIRONMENT
+          value: staging
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
-              name: sentry
+              name: new-sentry
               key: dsn
         - name: SECRET_KEY
           valueFrom:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -42,7 +42,7 @@ spec:
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
-              name: new-sentry
+              name: sentry
               key: dsn
         - name: SECRET_KEY
           valueFrom:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,10 +1,10 @@
 boto3==1.10.8
 django==2.2.10
 django-storages==1.6.5
-raven==6.9.0
 uwsgi==2.0.17
 requests==2.20.0
 django_jinja==2.4.1
 logstash-formatter==0.5.14
 git+git://github.com/ministryofjustice/cla_common.git@0.3.3#egg=cla_common==0.3.3
 botocore==1.13.8
+sentry-sdk==0.17.6


### PR DESCRIPTION
## What does this pull request do?
Switches from Raven library to Sentry SDK, and starts passing an `environment` tag.

## Any other changes that would benefit highlighting?
Uses the same secret name for DSN, so merging this PR will still send data to the old Sentry instance, eg https://sentry.service.dsd.io/mojds/staging-fala/issues/63232/ (triggered via a deliberate exception-causing path that was temporarily added to the view code)
Once this is merged, we can reroute errors to the new Sentry instance by updating the secret.
The new instance has been tested on staging by using a different secret name in order to route to it before the existing secret is changed eg https://sentry.io/organizations/ministryofjustice/issues/1901244840/?project=5433781&query=is%3Aunresolved

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
