### PR TITLE
LGA-1454 - Fix environment name in production settings

### DIFF
--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -38,7 +38,7 @@ spec:
         - name: LAALAA_API_HOST
           value: https://laa-legal-adviser-api-production.cloud-platform.service.justice.gov.uk
         - name: ENVIRONMENT
-          value: staging
+          value: production
         - name: GA_ID
           value: "UA-37377084-6"
         - name: DJANGO_SETTINGS_MODULE


### PR DESCRIPTION
## What does this pull request do?
Properly sets the `ENVIRONMENT` env var to "production" on production, rather than "staging"

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
