### PR TITLE
Feature/LGA-1395 Environment Badge

### DIFF
--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -23,7 +23,7 @@ class AdviserView(TemplateView):
                 "GA_ID": settings.GA_ID,
                 "GOOGLE_MAPS_API_KEY": settings.GOOGLE_MAPS_API_KEY,
                 "LAALAA_API_HOST": settings.LAALAA_API_HOST,
-                "ENVIRONMENT": settings.ENVIRONMENT
+                "ENVIRONMENT": settings.ENVIRONMENT,
             }
         )
 

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -23,7 +23,7 @@ class AdviserView(TemplateView):
                 "GA_ID": settings.GA_ID,
                 "GOOGLE_MAPS_API_KEY": settings.GOOGLE_MAPS_API_KEY,
                 "LAALAA_API_HOST": settings.LAALAA_API_HOST,
-                "CLA_ENV": settings.CLA_ENV
+                "ENVIRONMENT": settings.ENVIRONMENT
             }
         )
 

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -23,6 +23,7 @@ class AdviserView(TemplateView):
                 "GA_ID": settings.GA_ID,
                 "GOOGLE_MAPS_API_KEY": settings.GOOGLE_MAPS_API_KEY,
                 "LAALAA_API_HOST": settings.LAALAA_API_HOST,
+                "CLA_ENV": settings.CLA_ENV
             }
         )
 

--- a/fala/assets-src/sass/main.scss
+++ b/fala/assets-src/sass/main.scss
@@ -129,7 +129,7 @@ p.govuk-body-l:last-child {
   display:initial;
 }
 
-body:not(.cla-production) {
+body:not(.fala-production) {
   .govuk-header__container {
     border-bottom-color:$laa-unknown-colour;
   }
@@ -138,7 +138,7 @@ body:not(.cla-production) {
   }
 }
 
-body.cla-staging {
+body.fala-staging {
   .govuk-header__container {
     border-bottom-color:$laa-staging-colour;
   }
@@ -147,7 +147,7 @@ body.cla-staging {
   }
 }
 
-body.cla-dev {
+body.fala-dev {
   .govuk-header__container {
     border-bottom-color:$laa-dev-colour;
   }

--- a/fala/assets-src/sass/main.scss
+++ b/fala/assets-src/sass/main.scss
@@ -29,6 +29,10 @@ $govuk-typography-use-rem: false;
 
 @import 'cla/elements';
 
+$laa-unknown-colour: govuk-colour("orange");
+$laa-staging-colour: govuk-colour("turquoise");
+$laa-dev-colour: govuk-colour("pink");
+
 @import 'tabs';
 @import 'fala-search';
 @import 'fala-results';
@@ -123,4 +127,31 @@ p.govuk-body-l:last-child {
 
 .js-enabled .laa-hide-if-no-js {
   display:initial;
+}
+
+body:not(.cla-production) {
+  .govuk-header__container {
+    border-bottom-color:$laa-unknown-colour;
+  }
+  .govuk-phase-banner__content__tag {
+    background-color:$laa-unknown-colour
+  }
+}
+
+body.cla-staging {
+  .govuk-header__container {
+    border-bottom-color:$laa-staging-colour;
+  }
+  .govuk-phase-banner__content__tag {
+    background-color:$laa-staging-colour;
+  }
+}
+
+body.cla-dev {
+  .govuk-header__container {
+    border-bottom-color:$laa-dev-colour;
+  }
+  .govuk-phase-banner__content__tag {
+    background-color:$laa-dev-colour;
+  }
 }

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -142,7 +142,7 @@ if "SENTRY_DSN" in os.environ:
 
 LAALAA_API_HOST = os.environ.get("LAALAA_API_HOST", None)
 
-CLA_ENV = os.environ.get("CLA_ENV", "dev")
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "dev")
 
 # Zendesk settings for feedback
 ZENDESK_API_USERNAME = os.environ.get("ZENDESK_API_USERNAME")

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -142,7 +142,7 @@ if "SENTRY_DSN" in os.environ:
 
 LAALAA_API_HOST = os.environ.get("LAALAA_API_HOST", None)
 
-ENVIRONMENT = os.environ.get("ENVIRONMENT", "dev")
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "unknown")
 
 # Zendesk settings for feedback
 ZENDESK_API_USERNAME = os.environ.get("ZENDESK_API_USERNAME")

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -142,6 +142,8 @@ if "SENTRY_DSN" in os.environ:
 
 LAALAA_API_HOST = os.environ.get("LAALAA_API_HOST", None)
 
+CLA_ENV = os.environ.get("CLA_ENV", "dev")
+
 # Zendesk settings for feedback
 ZENDESK_API_USERNAME = os.environ.get("ZENDESK_API_USERNAME")
 ZENDESK_API_TOKEN = os.environ.get("ZENDESK_API_TOKEN")

--- a/fala/settings/local.example.py
+++ b/fala/settings/local.example.py
@@ -5,3 +5,4 @@ DEBUG = True
 ALLOWED_HOSTS = ["localhost"]
 DEBUG_STATIC = True
 LAALAA_API_HOST = os.environ.get("LAALAA_API_HOST", "http://0.0.0.0:8001")
+ENVIRONMENT = "dev"

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -42,11 +42,11 @@
   <div class="govuk-phase-banner">
     <p class="govuk-phase-banner__content">
       <strong class="govuk-tag govuk-phase-banner__content__tag">
-        {% if CLA_ENV == "dev" %}
+        {% if ENVIRONMENT == "dev" %}
           Development
-        {% elif CLA_ENV == "staging" %}
+        {% elif ENVIRONMENT == "staging" %}
           Staging
-        {% elif CLA_ENV == "production" %}
+        {% elif ENVIRONMENT == "production" %}
           Beta
         {% endif %}
       </strong>

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -42,7 +42,13 @@
   <div class="govuk-phase-banner">
     <p class="govuk-phase-banner__content">
       <strong class="govuk-tag govuk-phase-banner__content__tag">
-        alpha
+        {% if CLA_ENV == "dev" %}
+          Development
+        {% elif CLA_ENV == "staging" %}
+          Staging
+        {% elif CLA_ENV == "production" %}
+          Beta
+        {% endif %}
       </strong>
       <span class="govuk-phase-banner__text">
         This is a new service – your <a class="govuk-link" href="https://forms.gle/Lvr3pU9BSju2LnDz8">feedback</a> will help us to improve it.

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -48,6 +48,8 @@
           Staging
         {% elif ENVIRONMENT == "production" %}
           Beta
+        {% else %}
+          {{ ENVIRONMENT.title() }}
         {% endif %}
       </strong>
       <span class="govuk-phase-banner__text">

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -8,7 +8,7 @@
     {% block stylesheets %}{% endblock %}
     {% block head %}{% endblock %}
   </head>
-  <body class="govuk-template__body {{ 'cla-' + ENVIRONMENT }}">
+  <body class="govuk-template__body {{ 'fala-' + ENVIRONMENT }}">
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <header class="govuk-header " role="banner" data-module="govuk-header">
       <div id="cookie-message" class="

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -8,7 +8,7 @@
     {% block stylesheets %}{% endblock %}
     {% block head %}{% endblock %}
   </head>
-  <body class="govuk-template__body {{ 'cla-' + CLA_ENV }}">
+  <body class="govuk-template__body {{ 'cla-' + ENVIRONMENT }}">
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <header class="govuk-header " role="banner" data-module="govuk-header">
       <div id="cookie-message" class="

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -8,7 +8,7 @@
     {% block stylesheets %}{% endblock %}
     {% block head %}{% endblock %}
   </head>
-  <body class="govuk-template__body ">
+  <body class="govuk-template__body {{ 'cla-' + CLA_ENV }}">
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <header class="govuk-header " role="banner" data-module="govuk-header">
       <div id="cookie-message" class="


### PR DESCRIPTION
## What does this pull request do?

- Adds a graphical indicator and badge to display the current working environment 
- Changes the name of the badge on production (and eventually live) from **Alpha** to **Beta**

## Any other changes that would benefit highlighting?

The name of the badge on production (and eventually live) has been changed to **Beta** from **Alpha** due to changes discussed outside of the ticket.

**You will have to recreate your `local.py` file from `local.example.py` in order for these changes to take fully effect.** This is because we do not want the default environment to be set to dev if for example, we was on a production environment and the production env var was removed, we would be seeing a badge of dev on production. 

Not creating your `local.py` will cause your badge to be **Unknown** instead of **Development**

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
