### PR TITLE
LGA-1465 - uwsgi graceful termination workaround 

### DIFF
--- a/conf/uwsgi.ini
+++ b/conf/uwsgi.ini
@@ -11,3 +11,4 @@ harakiri=30
 logger-req=stdio
 logformat={"process_name": "uwsgi", "timestamp_msec": %(tmsecs), "method": "%(method)", "uri": "%(uri)", "proto": "%(proto)", "status": %(status), "referer": "%(referer)", "user_agent": "%(uagent)", "remote_addr": "%(addr)", "http_host": "%(host)", "pid": %(pid), "worker_id": %(wid), "core": %(core), "async_switches": %(switches), "io_errors": %(ioerr), "rq_size": %(cl), "rs_time_ms": %(msecs), "rs_size": %(size), "rs_header_size": %(hsize), "rs_header_count": %(headers)}
 post-buffering=1
+die-on-term=True

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: laa-fala-app
     spec:
+      terminationGracePeriodSeconds: 30
       containers:
       - image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-access/fala:master
         name: app
@@ -27,6 +28,10 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 1
           periodSeconds: 10
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep","10"]
         ports:
         - containerPort: 8000
           name: http


### PR DESCRIPTION
## What does this pull request do?

Add preStop lifecycle hook and terminationGracePeriod to allow enough time for uwsgi finish processing requests

Changes explained:

- **die-on-term** - respect the convention of shutting down the instance
- **preStop** - Sleep for 30 seconds. Called before receiving SIGTERM. Aim here is to sleep enough time for the current requests to finish.
- **terminationGracePeriodSeconds** - Amount of time kubernetes waits before sending us the SIGKILL signal.

Important note from the [kubernetes documentation ](https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-terminating-with-grace)on how the preStop and terminationGracePeriodSeconds interact:

> It’s important to note that this(_terminationGracePeriodSeconds_) happens in parallel to the preStop hook and the SIGTERM signal. Kubernetes does not wait for the preStop hook to finish.
If your app finishes shutting down and exits before the terminationGracePeriod is done, Kubernetes moves to the next step immediately.

## Any other changes that would benefit highlighting?

Related PR https://github.com/ministryofjustice/cla_backend/pull/665
Set sleep time to 10 seconds as opposed to 30 in the related PR -- because these requests should be lighter than the cla_backend project

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
