### PR TITLE
LGA-1510 Map focus colour (missing from previous deployment)

### DIFF
--- a/fala/assets-src/sass/_fala-results.scss
+++ b/fala/assets-src/sass/_fala-results.scss
@@ -8,6 +8,14 @@
       outline:none!important;
       background-color:transparent!important;
   }
+  [tabindex="0"]:focus {
+    > .gm-style-pbc + div {
+      box-shadow:0 0 0 2px govuk-colour("black") inset, 0 0 0 11px $govuk-focus-colour inset;
+    }
+    ~ div .gm-style-cc * {
+      background-color:transparent!important;
+    }
+  }
   a:focus {
     outline: solid 2px $govuk-focus-colour;
     outline-offset: 0;


### PR DESCRIPTION
## What does this pull request do?

Adds focus styling to the Google Map - missed off the previous PR for LGA-1510

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
