### PR TITLE
LGA-1897 - Add external DNS annotations to FALA ingress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - run:
@@ -47,7 +47,7 @@ jobs:
             pip install virtualenv
             virtualenv env
             source env/bin/activate
-            pip install pip==18.1
+            pip install setuptools pip==19.1 wheel
       - restore_cache:
           keys:
             - pip-v1-{{ checksum "requirements/base.txt" }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-buster
 
 ENV LC_CTYPE=C.UTF-8
 

--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -3,6 +3,9 @@ kind: Ingress
 metadata:
   name: laa-fala
   namespace: laa-fala-production
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: laa-fala-laa-fala-production-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:

--- a/kubernetes_deploy/staging/ingress.yml
+++ b/kubernetes_deploy/staging/ingress.yml
@@ -3,6 +3,9 @@ kind: Ingress
 metadata:
   name: laa-fala
   namespace: laa-fala-staging
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: laa-fala-laa-fala-staging-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
## What does this pull request do?

- Add external DNS annotations to FALA ingress.
- Update circleci python image used for testing from circleci/python:3.7 to cimg/python:3.7 otherwise it was failing to build uwsgi
- Fix base image to debian buster
  - There has been a new release of debian(bullseye) since the creation of the Dockerfile
  - This release is incompatible with node8 that is built for this project
  - LGA-1909 has been created to capture the need to upgrade node for this project

## Any other changes that would benefit highlighting?

Cloud Platforms is migrating from a self-hosted Kubernetes cluster to EKS.
As part of this migration, the load balancer will need to stop directing traffic to the existing instance of our service and start directing it to an instance of our service running on the new cluster. This cutover will be controlled by us, by annotations on our Ingress objects.

In preparation for this, we need to add annotations now that specify to direct all traffic to the current instance, so that when the load balancer starts reading these annotations it knows to continue as it is now until those annotations change

The `blue` suffix means to use the ingress in “live-1”

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrate-to-live.html#step-2-amend-and-apply-your-quot-live-1-quot-ingress-resource


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
