### PR TITLE
LGA-1962 - Remove live-1 staging deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ workflows:
           requires:
             - lint
             - test
-          context: laa-fala-live-1
+          context: laa-fala
       - staging_deploy_approval:
           type: approval
           requires:
@@ -144,7 +144,7 @@ workflows:
           requires:
             - staging_deploy_approval
           context:
-            - laa-fala-live-1
+            - laa-fala
             - laa-fala-live-staging
 
       - production_deploy_approval:
@@ -170,5 +170,5 @@ workflows:
           requires:
             - production_deploy_approval
           context:
-            - laa-fala-live-1
+            - laa-fala
             - laa-fala-live-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,15 +139,6 @@ workflows:
             - build
 
       - deploy:
-          name: staging_deploy_live1
-          environment: staging-live1
-          requires:
-            - staging_deploy_approval
-          context:
-            - laa-fala-live-1
-            - laa-fala-live1-staging
-
-      - deploy:
           name: staging_deploy_live
           environment: staging
           requires:
@@ -159,7 +150,7 @@ workflows:
       - production_deploy_approval:
           type: approval
           requires:
-            - staging_deploy_live1
+            - staging_deploy_live
           filters:
             branches:
               only:


### PR DESCRIPTION
## What does this pull request do?

Remove live-1 staging deployment.
Use new laa-fala context for non live-1 deployments

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
