### PR TITLE
Update ingress for production namespace

### DIFF
--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -1,12 +1,14 @@
 apiVersion:  networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: laa-fala
+  name: laa-fala-v122
   namespace: laa-fala-production
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: laa-fala-laa-fala-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: laa-fala-v122-laa-fala-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
 spec:
+  ingressClassName: "modsec"
   tls:
   - hosts:
     - laa-fala-production.apps.live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## What does this pull request do?

Fix not updating ingress name in previous PR

## Any other changes that would benefit highlighting?

In addition to https://github.com/ministryofjustice/fala/pull/130 but updates the production namespace which was forgotten in that PR

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
