### PR TITLE
LGA-2126 - Update ingress name for production namespace

### DIFF
--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -1,7 +1,7 @@
 apiVersion:  networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: laa-fala
+  name: laa-fala-v122
   namespace: laa-fala-production
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-fala-v122-laa-fala-production-green


### PR DESCRIPTION
## What does this pull request do?

Update ingress name for production namespace

## Any other changes that would benefit highlighting?

In addition to https://github.com/ministryofjustice/fala/pull/130 but updates the production namespace which was forgotten in that PR

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
