### PR TITLE
LGA 2704: Fix issue where markers are not not correctly being loaded on the map

### DIFF
--- a/kubernetes_deploy/development/collect-static-cronjob.yml
+++ b/kubernetes_deploy/development/collect-static-cronjob.yml
@@ -5,7 +5,7 @@ metadata:
     kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
   name: laa-fala-collect-static-cronjob
 spec:
-  schedule: "0 0 * * *"
+  schedule: "0 */4 * * *"
   jobTemplate:
     spec:
       template:

--- a/kubernetes_deploy/production/collect-static-cronjob.yml
+++ b/kubernetes_deploy/production/collect-static-cronjob.yml
@@ -5,7 +5,7 @@ metadata:
     kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
   name: laa-fala-collect-static-cronjob
 spec:
-  schedule: "0 0 * * *"
+  schedule: "0 */4 * * *"
   jobTemplate:
     spec:
       template:

--- a/kubernetes_deploy/staging/collect-static-cronjob.yml
+++ b/kubernetes_deploy/staging/collect-static-cronjob.yml
@@ -5,7 +5,7 @@ metadata:
     kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
   name: laa-fala-collect-static-cronjob
 spec:
-  schedule: "0 0 * * *"
+  schedule: "0 */4 * * *"
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
## What does this pull request do?
### [LGA 2704](https://dsdmoj.atlassian.net/browse/LGA-2704)

- Changes the cronjob schedule, for getting new AWS Keys to every 4 hours, from every 24 hours.

## Any other changes that would benefit highlighting?

The reason for this change is that tokens are generated that were expiring at 00:07 the following day. The old implementation was getting a token at 00:00, which was set to expire in 7 minutes. The new implementation regularly gets a new token so that the client will not be given an outdated token.

To see the issue please visit: [Staging](https://staging.find-legal-advice.justice.gov.uk/?postcode=SW1)
The issue was temporarily fixed on live by manually running the script to get a new token, thus fixing the issue (Until 00:07 tomorrow)

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
