### PR TITLE
LGA-2712 - Restore logic for using an ajax base file for ajax requests

### DIFF
--- a/fala/templates/adviser/search.html
+++ b/fala/templates/adviser/search.html
@@ -1,4 +1,8 @@
-{% extends 'base.html' %}
+{% if request.headers.get('x-requested-with') == 'XMLHttpRequest' %}
+  {% extends 'ajax-base.html' %}
+{% else %}
+  {% extends 'base.html' %}
+{% endif %}
 
 {% import "macros/element.html" as Element %}
 {% import "macros/forms.html" as Form %}

--- a/fala/templates/ajax-base.html
+++ b/fala/templates/ajax-base.html
@@ -1,0 +1,12 @@
+<div class="find-legal-adviser">
+  <div class="govuk-grid-column-full">
+    {% block search_results %}
+      {% include 'adviser/_results.html' %}
+    {% endblock %}
+    {% block search_form %}{% endblock %}
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">If you are a provider and your details are incorrect, please contact your contract manager.</p>
+  </div>
+</div>
+


### PR DESCRIPTION
## What does this pull request do?

Restore logic for using an ajax base file for ajax requests

## Any other changes that would benefit highlighting?

This was wrongfully removed on https://github.com/ministryofjustice/fala/pull/166 as part of a Django upgrade

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
