### PR TITLE
LGA-2727 - Remove deprecated batch/v1beta1 API version of CronJob

### DIFF
--- a/kubernetes_deploy/development/collect-static-cronjob.yml
+++ b/kubernetes_deploy/development/collect-static-cronjob.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations:

--- a/kubernetes_deploy/production/collect-static-cronjob.yml
+++ b/kubernetes_deploy/production/collect-static-cronjob.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations:

--- a/kubernetes_deploy/staging/collect-static-cronjob.yml
+++ b/kubernetes_deploy/staging/collect-static-cronjob.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations:


### PR DESCRIPTION
## What does this pull request do?

Remove deprecated batch/v1beta1 API version of CronJob

## Any other changes that would benefit highlighting?

[The batch/v1beta1 API version of CronJob is no longer served as of v1.25.](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125)

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
