### PR TITLE
LGA-2757 Remove GA3 and add GTM

### DIFF
--- a/fala/apps/adviser/context_processors.py
+++ b/fala/apps/adviser/context_processors.py
@@ -1,9 +1,5 @@
 from django.conf import settings
 
 
-def ga_id(request):
-    return {"GA_ID": settings.GA_ID}
-
-
 def current_environment(request):
     return {"ENVIRONMENT": settings.ENVIRONMENT}

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -20,7 +20,6 @@ class AdviserView(TemplateView):
                 "form": form,
                 "data": form.search(),
                 "current_url": current_url,
-                "GA_ID": settings.GA_ID,
                 "GOOGLE_MAPS_API_KEY": settings.GOOGLE_MAPS_API_KEY,
                 "LAALAA_API_HOST": settings.LAALAA_API_HOST,
             }

--- a/fala/settings/base.py
+++ b/fala/settings/base.py
@@ -86,7 +86,6 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 # 'django.contrib.auth.context_processors.auth',
                 "django.contrib.messages.context_processors.messages",
-                "adviser.context_processors.ga_id",
                 "adviser.context_processors.current_environment",
             ],
         },
@@ -149,8 +148,6 @@ ZENDESK_GROUP_ID = os.environ.get("ZENDESK_GROUP_ID", 26974037)  # Find a Legal 
 ZENDESK_API_ENDPOINT = "https://ministryofjustice.zendesk.com/api/v2/"
 ZENDESK_REQUESTER_ID = os.environ.get("ZENDESK_REQUESTER_ID", 649762516)
 # defaults to 'anonymous feedback <noreply@ministryofjustice.zendesk.com>'
-
-GA_ID = os.environ.get("GA_ID")
 
 GOOGLE_MAPS_API_KEY = os.environ.get("GOOGLE_MAPS_API_KEY", "")
 

--- a/fala/templates/404.html
+++ b/fala/templates/404.html
@@ -2,6 +2,18 @@
 {% extends 'base.html' %}
 
 {% block before_main_js %}{% endblock %}
+  <script>
+  function tagMan() {  // Activate Google Tag Manager
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-WDJLHSKL');
+  }
+  </script>
+  {% if (request.COOKIES.get('cookiePermission') == 'Allowed') %}
+  <script>tagMan();</script>
+  {% endif %}
 {% block main_js %}{% endblock %}
 
 {% block page_title %}Page not found - 404 - {{ title }}{% endblock %}
@@ -13,13 +25,4 @@
     <p class="govuk-body">If you entered a web address please check it was correct.</p>
     <p class="govuk-body">Alternatively return to <a class="govuk-link" href="{{ url('adviser') }}">{{ title }} homepage</a> and try again.</p>
   </div>
-{% endblock %}
-
-{% block after_main_js %}
-  {% if GA_ID %}
-    <script>
-      ga('create', '{{ GA_ID }}', 'auto');
-      ga('send', 'pageview', '/404' + window.location.pathname + window.location.search);
-    </script>
-  {% endif %}
 {% endblock %}

--- a/fala/templates/404.html
+++ b/fala/templates/404.html
@@ -2,18 +2,6 @@
 {% extends 'base.html' %}
 
 {% block before_main_js %}{% endblock %}
-  <script>
-  function tagMan() {  // Activate Google Tag Manager
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-WDJLHSKL');
-  }
-  </script>
-  {% if (request.COOKIES.get('cookiePermission') == 'Allowed') %}
-  <script>tagMan();</script>
-  {% endif %}
 {% block main_js %}{% endblock %}
 
 {% block page_title %}Page not found - 404 - {{ title }}{% endblock %}

--- a/fala/templates/500.html
+++ b/fala/templates/500.html
@@ -2,18 +2,6 @@
 {% extends 'base.html' %}
 
 {% block before_main_js %}{% endblock %}
-  <script>
-  function tagMan() {  // Activate Google Tag Manager
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-WDJLHSKL');
-  }
-  </script>
-  {% if (request.COOKIES.get('cookiePermission') == 'Allowed') %}
-  <script>tagMan();</script>
-  {% endif %}
 {% block main_js %}{% endblock %}
 
 {% block page_title %}{{ _('Sorry, there is a problem with the service - Find a legal advisor or family mediator - GOV.UK') }} - {{ super() }}{% endblock %}

--- a/fala/templates/500.html
+++ b/fala/templates/500.html
@@ -2,6 +2,18 @@
 {% extends 'base.html' %}
 
 {% block before_main_js %}{% endblock %}
+  <script>
+  function tagMan() {  // Activate Google Tag Manager
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-WDJLHSKL');
+  }
+  </script>
+  {% if (request.COOKIES.get('cookiePermission') == 'Allowed') %}
+  <script>tagMan();</script>
+  {% endif %}
 {% block main_js %}{% endblock %}
 
 {% block page_title %}{{ _('Sorry, there is a problem with the service - Find a legal advisor or family mediator - GOV.UK') }} - {{ super() }}{% endblock %}
@@ -17,11 +29,3 @@
   </div>
 {% endblock %}
 
-{% block after_main_js %}
-  {% if GA_ID %}
-    <script>
-      ga('create', '{{ GA_ID }}', 'auto');
-      ga('send', 'pageview', '/404' + window.location.pathname + window.location.search);
-    </script>
-  {% endif %}
-{% endblock %}

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -15,16 +15,23 @@
     </style>
   {% endif %}
   <script>
+  function tagMan() {  // Activate Google Tag Manager
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-WDJLHSKL');
+  }
+  </script>
+  
+  {% if (request.COOKIES.get('cookiePermission') == 'Allowed') %}
+  <script>tagMan();</script>
+  {% endif %}
+  <script>
     /* Modernizr 2.8.3 (Custom Build) | MIT & BSD
      * Build: http://modernizr.com/download/#-mq-teststyles
      */
     window.Modernizr=function(a,b,c){function v(a){i.cssText=a}function w(a,b){return v(prefixes.join(a+";")+(b||""))}function x(a,b){return typeof a===b}function y(a,b){return!!~(""+a).indexOf(b)}function z(a,b,d){for(var e in a){var f=b[a[e]];if(f!==c)return d===!1?a[e]:x(f,"function")?f.bind(d||b):f}return!1}var d="2.8.3",e={},f=b.documentElement,g="modernizr",h=b.createElement(g),i=h.style,j,k={}.toString,l={},m={},n={},o=[],p=o.slice,q,r=function(a,c,d,e){var h,i,j,k,l=b.createElement("div"),m=b.body,n=m||b.createElement("body");if(parseInt(d,10))while(d--)j=b.createElement("div"),j.id=e?e[d]:g+(d+1),l.appendChild(j);return h=["&#173;",'<style id="s',g,'">',a,"</style>"].join(""),l.id=g,(m?l:n).innerHTML+=h,n.appendChild(l),m||(n.style.background="",n.style.overflow="hidden",k=f.style.overflow,f.style.overflow="hidden",f.appendChild(n)),i=c(l,a),m?l.parentNode.removeChild(l):(n.parentNode.removeChild(n),f.style.overflow=k),!!i},s=function(b){var c=a.matchMedia||a.msMatchMedia;if(c)return c(b)&&c(b).matches||!1;var d;return r("@media "+b+" { #"+g+" { position: absolute; } }",function(b){d=(a.getComputedStyle?getComputedStyle(b,null):b.currentStyle)["position"]=="absolute"}),d},t={}.hasOwnProperty,u;!x(t,"undefined")&&!x(t.call,"undefined")?u=function(a,b){return t.call(a,b)}:u=function(a,b){return b in a&&x(a.constructor.prototype[b],"undefined")},Function.prototype.bind||(Function.prototype.bind=function(b){var c=this;if(typeof c!="function")throw new TypeError;var d=p.call(arguments,1),e=function(){if(this instanceof e){var a=function(){};a.prototype=c.prototype;var f=new a,g=c.apply(f,d.concat(p.call(arguments)));return Object(g)===g?g:f}return c.apply(b,d.concat(p.call(arguments)))};return e});for(var A in l)u(l,A)&&(q=A.toLowerCase(),e[q]=l[A](),o.push((e[q]?"":"no-")+q));return e.addTest=function(a,b){if(typeof a=="object")for(var d in a)u(a,d)&&e.addTest(d,a[d]);else{a=a.toLowerCase();if(e[a]!==c)return e;b=typeof b=="function"?b():b,typeof enableClasses!="undefined"&&enableClasses&&(f.className+=" "+(b?"":"no-")+a),e[a]=b}return e},v(""),h=j=null,e._version=d,e.mq=s,e.testStyles=r,e}(this,this.document);
-  </script>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
   </script>
 {% endblock %}
 
@@ -153,22 +160,6 @@
 
 {% block before_main_js %}
   {{ super() }}
-  <script>
-    function performGoogleAnalyticalTasks() {
-      {% if GA_ID %}
-        ga('create', '{{ GA_ID }}', 'auto');
-        ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));
-        ga('send', 'pageview');
-      {% else %}
-        console.log("Analyzed - no GA ID");
-      {% endif %}
-    }
-  </script>
-  {% if request.COOKIES.get('cookiePermission') == 'Allowed' %}
-    <script>
-      performGoogleAnalyticalTasks()
-    </script>
-  {% endif %}
   <script src="//maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}"></script>
   <script>
     window.LABELS = {

--- a/fala/templates/feedback/index.html
+++ b/fala/templates/feedback/index.html
@@ -1,5 +1,20 @@
 {% extends 'base.html' %}
 
+{% block before_main_js %}{% endblock %}
+  <script>
+  function tagMan() {  // Activate Google Tag Manager
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-WDJLHSKL');
+  }
+  </script>
+  {% if (request.COOKIES.get('cookiePermission') == 'Allowed') %}
+  <script>tagMan();</script>
+  {% endif %}
+{% block main_js %}{% endblock %}
+
 {% block page_title %}Feedback - {{ title }}{% endblock %}
 
 {% block content %}
@@ -27,11 +42,3 @@
   </form>
 {% endblock %}
 
-{% block after_main_js %}
-  {{ super() }}
-  {% if GA_ID and error %}
-    <script>
-      ga('send', 'event', 'error', 'feedback-error');
-    </script>
-  {% endif %}
-{% endblock %}

--- a/fala/templates/feedback/index.html
+++ b/fala/templates/feedback/index.html
@@ -1,18 +1,6 @@
 {% extends 'base.html' %}
 
 {% block before_main_js %}{% endblock %}
-  <script>
-  function tagMan() {  // Activate Google Tag Manager
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-WDJLHSKL');
-  }
-  </script>
-  {% if (request.COOKIES.get('cookiePermission') == 'Allowed') %}
-  <script>tagMan();</script>
-  {% endif %}
 {% block main_js %}{% endblock %}
 
 {% block page_title %}Feedback - {{ title }}{% endblock %}

--- a/fala/templates/generic-py-base.html
+++ b/fala/templates/generic-py-base.html
@@ -122,7 +122,7 @@
         $("#cookieAccept").click(function() {
           setCookie("cookiePermission", "Allowed", 30);
           $(".laa-cookie-banner").addClass("laa-cookies-accepted");
-          performGoogleAnalyticalTasks();
+          tagMan();
         });
         $("#cookieReject").click(function() {
           eraseCookie("cookiePermission");

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -45,8 +45,6 @@ spec:
           value: https://laa-legal-adviser-api-production.cloud-platform.service.justice.gov.uk
         - name: ENVIRONMENT
           value: production
-        - name: GA_ID
-          value: "UA-37377084-6"
         - name: DJANGO_SETTINGS_MODULE
           value: "fala.settings.production"
         - name: SENTRY_DSN


### PR DESCRIPTION
## What does this pull request do?

Remove GA3, Use Google Tag Manager to call GA4.

## Any other changes that would benefit highlighting?

Hardcoded ID as simpler and won't change. Using existing cookie framework to implement.
Using inline script as per existing approach, but this may be something of a refactor at some point to put all scripts in files.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
