### PR TITLE
pip-compile error messages improved, 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             - "~/.cache/pip"
       - run:
           name: Check for changes with pip-compile
-          command: ls requirements/source/* | xargs pre-commit run pip-compile --files
+          command: ls requirements/source/* | xargs pre-commit run pip-compile --show-diff-on-failure --files
   test:
     docker:
       - image: cimg/python:3.12

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,20 +15,20 @@ repos:
         language_version: python3.12
         name: pip-compile requirements-dev.in
         files: requirements-(base|dev|pre-commit).in
-        args: [ requirements/source/requirements-dev.in, "--output-file", requirements/generated/requirements-dev.txt ]
+        args: [ requirements/source/requirements-dev.in, "--output-file", requirements/generated/requirements-dev.txt, "-q" ]
       - id: pip-compile
         language_version: python3.12
         name: pip-compile requirements-pre-commit.in
         files: requirements-pre-commit.in
-        args: [ requirements/source/requirements-pre-commit.in, "--output-file", requirements/generated/requirements-pre-commit.txt ]
+        args: [ requirements/source/requirements-pre-commit.in, "--output-file", requirements/generated/requirements-pre-commit.txt, "-q" ]
       - id: pip-compile
         language_version: python3.12
         name: pip-compile requirements-lint.in
         files: requirements-lint.in
-        args: [ requirements/source/requirements-lint.in, "--output-file", requirements/generated/requirements-lint.txt ]
+        args: [ requirements/source/requirements-lint.in, "--output-file", requirements/generated/requirements-lint.txt, "-q" ]
       - id: pip-compile
         language_version: python3.12
         name: pip-compile requirements-production.in
         files: requirements-(base|production).in
-        args: [requirements/source/requirements-production.in, "--output-file", requirements/generated/requirements-production.txt]
+        args: [requirements/source/requirements-production.in, "--output-file", requirements/generated/requirements-production.txt, "-q"]
 


### PR DESCRIPTION
When CircleCI runs pre-commit, that runs *pip-compile*, this PR improves the output to show any error.

Before this PR it displayed the full compiled file:
![Screenshot 2024-03-28 at 16 39 32](https://github.com/ministryofjustice/fala/assets/307612/19e6c5ce-4178-4919-a23b-4ea7a1a09e9f)
which is not particularly helpful for seeing the problem. So we add `-q` for quiet.

With this PR, it displays the 'git diff', which shows the modification, which is what pre-commit considers an error:
![Screenshot 2024-03-28 at 16 40 28](https://github.com/ministryofjustice/fala/assets/307612/37bfc542-55c5-46e0-8217-fc55e6f97ecb)
We can see the problem now - the version of `black`.

(We see that pip-compile has updated `black`, so the author of the PR has forgotten to run pip-compile. So the build is right to fail.)

These examples are from testing on this branch: https://app.circleci.com/pipelines/github/ministryofjustice/fala?branch=dependabot%2Fpip%2Frequirements%2Fgenerated%2Fblack-24.3.0 

The alternative scenario is that someone is on the command-line and they run pre-commit, and pip-compile encounters an error. In this case, this PR hides the unhelpful pip-compile output (the `-q`). (It is unchanged that they have to run `git diff` to see the error.)

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
