### PR TITLE
nunjucks version - clarify we use the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "mojular-govuk-elements": "mojular/govuk-elements#0.2.0",
     "mojular-moj-elements": "mojular/moj-elements#0.2.0",
     "mojular-templates": "mojular/templates#0.0.6",
-    "nunjucks": "^3.2.0"
+    "nunjucks": "^3.2.4"
   },
   "devDependencies": {
     "browser-sync": "^2.27.10",


### PR DESCRIPTION
The `^` in ^3.2.0` already means use a later patch version if available, and indeed package-lock is already using 3.2.4, so this PR doesn't change anything in the deployed app.

This PR is useful though to tell Snyk that we're on a good version - see https://github.com/ministryofjustice/fala/pull/210/files

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
