### PR TITLE
Upgrade pip-tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
     - id: flake8
 -   repo: https://github.com/jazzband/pip-tools
-    rev: 6.13.0
+    rev: 7.4.1
     hooks:
       - id: pip-compile
         language_version: python3.12

--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -23,7 +23,7 @@ cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.3.2
     # via requests
-cla_common @ https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.3.tar.gz
+cla-common @ https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.3.tar.gz
     # via -r requirements/source/requirements-base.in
 click==8.1.7
     # via pip-tools
@@ -65,14 +65,16 @@ nodeenv==1.8.0
     # via pre-commit
 packaging==24.0
     # via build
-pip-tools==6.13.0
+pip-tools==7.4.1
     # via -r requirements/source/requirements-dev.in
 platformdirs==4.2.0
     # via virtualenv
 pre-commit==3.7.0
     # via -r requirements/source/requirements-pre-commit.in
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 python-dateutil==2.9.0.post0
     # via
     #   botocore

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -19,7 +19,7 @@ certifi==2024.2.2
     #   sentry-sdk
 charset-normalizer==3.3.2
     # via requests
-cla_common @ https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.3.tar.gz
+cla-common @ https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.3.tar.gz
     # via -r requirements/source/requirements-base.in
 django==5.0.3
     # via

--- a/requirements/source/requirements-dev.in
+++ b/requirements/source/requirements-dev.in
@@ -1,4 +1,4 @@
 -r requirements-base.in
 -r requirements-pre-commit.in
 # pip-tools is pinned because it's important to be in step with .pre-commit-config.yaml
-pip-tools==6.13.0
+pip-tools==7.4.1


### PR DESCRIPTION
7.4.1 is the latest release.

There's no particular drive to do this upgrade, other than the desire to be generally up to date.

The upgrade results in subtle formatting changes to the generated requirements*.txt, such as:
```
-cla_common
+cla-common
```

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
