### PR TITLE
EL-1435: Display params on results page and allow return to search

### DIFF
--- a/fala/apps/adviser/tests/test_search_view_function.py
+++ b/fala/apps/adviser/tests/test_search_view_function.py
@@ -39,6 +39,12 @@ class ResultsPageWithBothOrgAndPostcodeTest(SimpleTestCase):
             html=True,
         )
 
+    def test_search_parameters_box_is_visible(self):
+        response = self.client.get(self.url, self.data)
+        soup = bs4.BeautifulSoup(response.content)
+        search_params_box = soup.find("div", class_="laa-fala__grey-box")
+        self.assertIsNotNone(search_params_box)
+
     def test_search_returns_results_list(self):
         response = self.client.get(self.url, self.data)
         soup = bs4.BeautifulSoup(response.content, "html.parser")
@@ -69,6 +75,30 @@ class ResultsPageWithJustPostcodeTest(SimpleTestCase):
             + '<strong class="notranslate" translate="no">PE30</strong> . </span>',
             html=True,
         )
+
+    def test_search_parameters_box_contains_only_postcode_and_categories(self):
+        response = self.client.get(self.url, self.data)
+        soup = bs4.BeautifulSoup(response.content)
+        search_params_box = soup.find("div", class_="laa-fala__grey-box")
+        # replace the spaces in the HTML for ease of comparison
+        content = search_params_box.text.replace("\n", "")
+        self.assertEqual(content, "Postcode: PE30Categories: Debt Change search")
+
+
+@override_settings(FEATURE_FLAG_NO_MAP=True)
+class ResultsPageWithJustOrgTest(SimpleTestCase):
+    client = Client()
+    url = reverse("search")
+
+    data = {"name": "foo", "categories": ["deb", "edu"]}
+
+    def test_search_parameters_box_contains_only_organisation_and_categories(self):
+        response = self.client.get(self.url, self.data)
+        soup = bs4.BeautifulSoup(response.content)
+        search_params_box = soup.find("div", class_="laa-fala__grey-box")
+        # replace the spaces in the HTML for ease of comparison
+        content = search_params_box.text.replace("\n", "")
+        self.assertEqual(content, "Organisation: fooCategories: Debt, Education Change search")
 
 
 @override_settings(FEATURE_FLAG_NO_MAP=True)

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -5,6 +5,7 @@ from django.views.generic import TemplateView, ListView
 
 from .forms import AdviserSearchForm
 from .laa_laa_paginator import LaaLaaPaginator
+from laalaa.api import PROVIDER_CATEGORIES
 
 
 # https://docs.djangoproject.com/en/5.0/topics/class-based-views - documentation on Class-based views
@@ -59,7 +60,7 @@ class SearchView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({"form": self._form, "data": self._data})
+        context.update({"form": self._form, "data": self._data, "category_selection": self.display_category()})
         # Only paginate on success. _data is already paginated, so we need our own paginator
         # that can answer questions about next and previous buttons etc.
         if self._data:
@@ -73,3 +74,11 @@ class SearchView(ListView):
 
             context.update({"pages": pages, "params": params, "categories": categories})
         return context
+
+    def display_category(self):
+        if "categories" in self._form.cleaned_data:
+            categories = [PROVIDER_CATEGORIES[cat] for cat in self._form.cleaned_data["categories"]]
+            formatted_categories = ", ".join(map(str, categories))
+
+            return formatted_categories
+        return []

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="govuk-grid-column-full">
     <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
-    <h1>Search results</h1>
+    <h1 class="govuk-heading-xl">Search results</h1>
     <div class="laa-fala__grey-box govuk-!-margin-bottom-6">
       <ul class="govuk-list" role="list">
         {% if form.postcode.value() %}

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -4,6 +4,31 @@
   <div class="govuk-grid-column-full">
     <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
     <h1>Search results</h1>
+    <div class="laa-fala__grey-box govuk-!-margin-bottom-6">
+      <ul class="govuk-list" role="list">
+        {% if form.postcode.value() %}
+          <li class="govuk-body notranslate" role="listitem" translate="no">Postcode: {{ form.postcode.value() }}</li>
+        {% endif %}
+        {% if form.name.value() %}
+          <li class="govuk-body notranslate" role="listitem" translate="no">Organisation: {{ form.name.value() }}</li>
+        {% endif %}
+        {% if category_selection %}
+          <li class="govuk-body notranslate" role="listitem" translate="no">Categories: {{ category_selection }} </li>
+        {% endif %}
+      </ul>
+
+      <form action="/" method="GET" novalidate>
+        <input type="hidden" name="postcode" value="{{ form.postcode.value() }}">
+        <input type="hidden" name="name" value="{{ form.name.value() }}">
+        {% for value, label_text in form.categories.field.choices %}
+          {% if label_text in category_selection.split(", ") %}
+            <input type="hidden" name="categories" value="{{ value }}">
+          {% endif %}
+        {% endfor %}
+        <button type="submit" class="govuk-button govuk-!-margin-bottom-2" id="changeSearchButton" name="search">Change search</button>
+      </form>
+    </div>
+
     <span class="results-header">
     {% if data.count > 0 %}
       {% if data.origin %}

--- a/fala/templates/macros/element.html
+++ b/fala/templates/macros/element.html
@@ -19,7 +19,7 @@
     {% endif %}
     <div class="alert-message govuk-{{type}}-summary">
       {% if title %}
-        <h2 class="alert-header govuk-heading-l govuk-{{type}}-summary__title" id="alert-heading-{{type}}">{{ _(title) }}</h3>
+        <h2 class="alert-header govuk-heading-l govuk-{{type}}-summary__title" id="alert-heading-{{type}}">{{ _(title) }}</h2>
       {% endif %}
       {{ caller() }}
     </div>


### PR DESCRIPTION
## What does this pull request do?

This pull request implements the grey 'change search' on the results.html. The box shows the user their current search parameters and also have a button that allows them to go back to the search.html and perform a new search.

When they change their search, their previous search params are populated on the search page for them to edit.

When they do not add postcode or org, this param will not render in the grey box on results.html

## Any other changes that would benefit highlighting?

To translate the categories on the results.html to nice strings, we have had to use the code which gets them from the LAALAA api. ~~My only concern is we will be hitting this API a lot more to get the categories.~~

~~I couldn't see a simple way to just store whatever is returned as the categories from the API (was thinking something like Ruby's `@variable ||=` but couldn't find a good python equivalent).~~

~~We could implement caching but that seemed like a fairly big-ish change so I haven't done it for now. Maybe a follow up ticket if we think we're hitting the API too much? Maybe it is already caching?~~

Update - the categories are being loaded when the application starts so they are saved/cached already. No further caching work needed!

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
