### PR TITLE
EL-1527: Add org name to google map link

### DIFF
--- a/fala/apps/adviser/templatetags/adviser_extras.py
+++ b/fala/apps/adviser/templatetags/adviser_extras.py
@@ -34,13 +34,13 @@ def to_fala_page_url(context, value, url_path):
 
 @library.filter
 def google_map_params(item):
-    organisation_type = item.get("type", "")
     organisation_name = item.get("organisation", {}).get("name", "")
     location = item.get("location", {})
+    office_type = location.get("type", "")
     address = location.get("address", "")
     postcode = location.get("postcode", "")
 
-    if "outreach" not in organisation_type.lower() and organisation_name:
+    if "outreach" not in office_type.lower() and organisation_name:
         if postcode and address:
             return {"api": 1, "query": f"{organisation_name} {address} {postcode}"}
         elif address:

--- a/fala/apps/adviser/templatetags/adviser_extras.py
+++ b/fala/apps/adviser/templatetags/adviser_extras.py
@@ -34,17 +34,22 @@ def to_fala_page_url(context, value, url_path):
 
 @library.filter
 def google_map_params(item):
+    organisation_type = item.get("type", "")
     organisation_name = item.get("organisation", {}).get("name", "")
     location = item.get("location", {})
     address = location.get("address", "")
     postcode = location.get("postcode", "")
 
-    if organisation_name:
+    if "outreach" not in organisation_type.lower() and organisation_name:
         if postcode and address:
             return {"api": 1, "query": f"{organisation_name} {address} {postcode}"}
         elif address:
             return {"api": 1, "query": f"{organisation_name} {address}"}
         else:
             return {"api": 1, "query": f"{organisation_name} {postcode}"}
+    elif postcode and address:
+        return {"api": 1, "query": f"{address} {postcode}"}
+    elif address:
+        return {"api": 1, "query": address}
     else:
         return {"api": 1, "query": postcode}

--- a/fala/apps/adviser/templatetags/adviser_extras.py
+++ b/fala/apps/adviser/templatetags/adviser_extras.py
@@ -33,10 +33,18 @@ def to_fala_page_url(context, value, url_path):
 
 
 @library.filter
-def google_map_params(location):
-    if "postcode" in location and "address" in location:
-        return {"api": 1, "query": f"{location['address']} {location['postcode']}"}
-    elif "address" in location:
-        return {"api": 1, "query": location["address"]}
+def google_map_params(item):
+    organisation_name = item.get("organisation", {}).get("name", "")
+    location = item.get("location", {})
+    address = location.get("address", "")
+    postcode = location.get("postcode", "")
+
+    if organisation_name:
+        if postcode and address:
+            return {"api": 1, "query": f"{organisation_name} {address} {postcode}"}
+        elif address:
+            return {"api": 1, "query": f"{organisation_name} {address}"}
+        else:
+            return {"api": 1, "query": f"{organisation_name} {postcode}"}
     else:
-        return {"api": 1, "query": location["postcode"]}
+        return {"api": 1, "query": postcode}

--- a/fala/apps/adviser/tests/test_adviser_extras.py
+++ b/fala/apps/adviser/tests/test_adviser_extras.py
@@ -17,7 +17,7 @@ class QueryToDictTest(unittest.TestCase):
         self.assertEqual([], result)
 
 
-class GoogleMapParamsTestNonOutreachOrg(unittest.TestCase):
+class GoogleMapParamsNonOutreachOrgTest(unittest.TestCase):
     def setUp(self):
         self.postcode = "S70 2JW"
         self.address = "The Core, County Way Barnsley"
@@ -60,7 +60,7 @@ class GoogleMapParamsTestNonOutreachOrg(unittest.TestCase):
         self.assertEqual(result, {"api": 1, "query": "S70 2JW"})
 
 
-class GoogleMapParamsTestOutreachOrg(unittest.TestCase):
+class GoogleMapParamsOutreachOrgTest(unittest.TestCase):
     def setUp(self):
         self.postcode = "S70 2JW"
         self.address = "The Core, County Way Barnsley"

--- a/fala/apps/adviser/tests/test_adviser_extras.py
+++ b/fala/apps/adviser/tests/test_adviser_extras.py
@@ -22,13 +22,12 @@ class GoogleMapParamsNonOutreachOrgTest(unittest.TestCase):
         self.postcode = "S70 2JW"
         self.address = "The Core, County Way Barnsley"
         self.name = "The Law Org"
-        self.type = ""
+        self.type = "Office"
 
     def test_google_map_params(self):
         item = {
             "organisation": {"name": self.name},
-            "location": {"address": self.address, "postcode": self.postcode},
-            "type": self.type,
+            "location": {"address": self.address, "postcode": self.postcode, "type": self.type},
         }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "The Law Org The Core, County Way Barnsley S70 2JW"})
@@ -36,8 +35,7 @@ class GoogleMapParamsNonOutreachOrgTest(unittest.TestCase):
     def test_map_params_without_postcode(self):
         item = {
             "organisation": {"name": self.name},
-            "location": {"address": self.address},
-            "type": self.type,
+            "location": {"address": self.address, "type": self.type},
         }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "The Law Org The Core, County Way Barnsley"})
@@ -45,16 +43,14 @@ class GoogleMapParamsNonOutreachOrgTest(unittest.TestCase):
     def test_map_params_without_address(self):
         item = {
             "organisation": {"name": self.name},
-            "location": {"postcode": self.postcode},
-            "type": self.type,
+            "location": {"postcode": self.postcode, "type": self.type},
         }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "The Law Org S70 2JW"})
 
     def test_map_params_without_name(self):
         item = {
-            "location": {"postcode": self.postcode},
-            "type": self.type,
+            "location": {"postcode": self.postcode, "type": self.type},
         }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "S70 2JW"})
@@ -70,8 +66,7 @@ class GoogleMapParamsOutreachOrgTest(unittest.TestCase):
     def test_google_map_params(self):
         item = {
             "organisation": {"name": self.name},
-            "location": {"address": self.address, "postcode": self.postcode},
-            "type": self.type,
+            "location": {"address": self.address, "postcode": self.postcode, "type": self.type},
         }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "The Core, County Way Barnsley S70 2JW"})
@@ -79,8 +74,7 @@ class GoogleMapParamsOutreachOrgTest(unittest.TestCase):
     def test_map_params_without_postcode(self):
         item = {
             "organisation": {"name": self.name},
-            "location": {"address": self.address},
-            "type": self.type,
+            "location": {"address": self.address, "type": self.type},
         }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "The Core, County Way Barnsley"})
@@ -88,8 +82,7 @@ class GoogleMapParamsOutreachOrgTest(unittest.TestCase):
     def test_map_params_without_address(self):
         item = {
             "organisation": {"name": self.name},
-            "location": {"postcode": self.postcode},
-            "type": self.type,
+            "location": {"postcode": self.postcode, "type": self.type},
         }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "S70 2JW"})

--- a/fala/apps/adviser/tests/test_adviser_extras.py
+++ b/fala/apps/adviser/tests/test_adviser_extras.py
@@ -17,16 +17,24 @@ class QueryToDictTest(unittest.TestCase):
         self.assertEqual([], result)
 
     def test_google_map_params(self):
-        location = {"address": "The Core, County Way Barnsley", "postcode": "S70 2JW"}
-        result = adviser_extras.google_map_params(location)
-        self.assertEqual(result, {"api": 1, "query": "The Core, County Way Barnsley S70 2JW"})
+        item = {
+            "organisation": {"name": "The Law Org"},
+            "location": {"address": "The Core, County Way Barnsley", "postcode": "S70 2JW"},
+        }
+        result = adviser_extras.google_map_params(item)
+        self.assertEqual(result, {"api": 1, "query": "The Law Org The Core, County Way Barnsley S70 2JW"})
 
     def test_map_params_without_postcode(self):
-        location = {"address": "The Core, County Way Barnsley"}
-        result = adviser_extras.google_map_params(location)
-        self.assertEqual(result, {"api": 1, "query": "The Core, County Way Barnsley"})
+        item = {"organisation": {"name": "The Law Org"}, "location": {"address": "The Core, County Way Barnsley"}}
+        result = adviser_extras.google_map_params(item)
+        self.assertEqual(result, {"api": 1, "query": "The Law Org The Core, County Way Barnsley"})
 
     def test_map_params_without_address(self):
-        location = {"postcode": "S70 2JW"}
-        result = adviser_extras.google_map_params(location)
+        item = {"organisation": {"name": "The Law Org"}, "location": {"postcode": "S70 2JW"}}
+        result = adviser_extras.google_map_params(item)
+        self.assertEqual(result, {"api": 1, "query": "The Law Org S70 2JW"})
+
+    def test_map_params_without_name(self):
+        item = {"location": {"postcode": "S70 2JW"}}
+        result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "S70 2JW"})

--- a/fala/apps/adviser/tests/test_adviser_extras.py
+++ b/fala/apps/adviser/tests/test_adviser_extras.py
@@ -16,25 +16,80 @@ class QueryToDictTest(unittest.TestCase):
         result = adviser_extras.query_to_dict("irrelevant", "http://localhost:8000/?postcode=SW1A&page=3", "potato")
         self.assertEqual([], result)
 
+
+class GoogleMapParamsTestNonOutreachOrg(unittest.TestCase):
+    def setUp(self):
+        self.postcode = "S70 2JW"
+        self.address = "The Core, County Way Barnsley"
+        self.name = "The Law Org"
+        self.type = ""
+
     def test_google_map_params(self):
         item = {
-            "organisation": {"name": "The Law Org"},
-            "location": {"address": "The Core, County Way Barnsley", "postcode": "S70 2JW"},
+            "organisation": {"name": self.name},
+            "location": {"address": self.address, "postcode": self.postcode},
+            "type": self.type,
         }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "The Law Org The Core, County Way Barnsley S70 2JW"})
 
     def test_map_params_without_postcode(self):
-        item = {"organisation": {"name": "The Law Org"}, "location": {"address": "The Core, County Way Barnsley"}}
+        item = {
+            "organisation": {"name": self.name},
+            "location": {"address": self.address},
+            "type": self.type,
+        }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "The Law Org The Core, County Way Barnsley"})
 
     def test_map_params_without_address(self):
-        item = {"organisation": {"name": "The Law Org"}, "location": {"postcode": "S70 2JW"}}
+        item = {
+            "organisation": {"name": self.name},
+            "location": {"postcode": self.postcode},
+            "type": self.type,
+        }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "The Law Org S70 2JW"})
 
     def test_map_params_without_name(self):
-        item = {"location": {"postcode": "S70 2JW"}}
+        item = {
+            "location": {"postcode": self.postcode},
+            "type": self.type,
+        }
+        result = adviser_extras.google_map_params(item)
+        self.assertEqual(result, {"api": 1, "query": "S70 2JW"})
+
+
+class GoogleMapParamsTestOutreachOrg(unittest.TestCase):
+    def setUp(self):
+        self.postcode = "S70 2JW"
+        self.address = "The Core, County Way Barnsley"
+        self.name = "The Law Org"
+        self.type = "Outreach office"
+
+    def test_google_map_params(self):
+        item = {
+            "organisation": {"name": self.name},
+            "location": {"address": self.address, "postcode": self.postcode},
+            "type": self.type,
+        }
+        result = adviser_extras.google_map_params(item)
+        self.assertEqual(result, {"api": 1, "query": "The Core, County Way Barnsley S70 2JW"})
+
+    def test_map_params_without_postcode(self):
+        item = {
+            "organisation": {"name": self.name},
+            "location": {"address": self.address},
+            "type": self.type,
+        }
+        result = adviser_extras.google_map_params(item)
+        self.assertEqual(result, {"api": 1, "query": "The Core, County Way Barnsley"})
+
+    def test_map_params_without_address(self):
+        item = {
+            "organisation": {"name": self.name},
+            "location": {"postcode": self.postcode},
+            "type": self.type,
+        }
         result = adviser_extras.google_map_params(item)
         self.assertEqual(result, {"api": 1, "query": "S70 2JW"})

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -96,7 +96,7 @@
               </ul>
             </div>
             {% endif %}
-            <a class="govuk-link" class="url" target="_blank" rel="noopener" href="https://www.google.com/maps/search/?{{ item.location|google_map_params|urlencode }}">
+            <a class="govuk-link" class="url" target="_blank" rel="noopener" href="https://www.google.com/maps/search/?{{ item|google_map_params|urlencode }}">
               View on map (opens in new tab)
             </a>
           </li>


### PR DESCRIPTION
## What does this pull request do?

Pass the org name into the google map link. We are also looking at the office type (namely if it is outreach or not) to know how to construct the google map link. 

## Any other changes that would benefit highlighting?

~~I'm wondering if this is the right thing to do - it sort of made some listings look worse. Sometimes the business name on google and the name we have don't match, which leads to a partial match search (not the end of the world.)~~

~~In some cases adding the name renders the business un-findable in Google. This seems to be the case for businesses operation outside of communal workspaces (where multiple businesses share the same address). We have rubbish data in LAALAA that doesn't always match Google very well.~~

Update: we've now added in the office type as a condition too, to help us generate better links for some offices. 

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
