### PR TITLE
El-1447: Add `dataLayer` variables for GA4

### DIFF
--- a/fala/templates/adviser/search.html
+++ b/fala/templates/adviser/search.html
@@ -32,14 +32,14 @@
       <div class="govuk-grid-column-full">
         <div class="laa-fala__grey-box">
 
-          <form action="search" novalidate>
+          <form action="search" id="fala_questions" novalidate>
             <div
               class="govuk-form-group
                 {% if (form.errors and form.errors['__all__']) %}
                   govuk-form-group--error
                 {% endif %}
                 "
-              id="fala_questions">
+              >
 
               {% set errorMessage = {'err': ""} %}
 

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -15,6 +15,26 @@
     </style>
   {% endif %}
   <script nonce="{{request.csp_nonce}}">
+    document.querySelector('#fala_questions').addEventListener('submit', function(e){
+    
+      // variables for postcode and organisation name
+      const postcode = document.querySelector("#id_postcode").value;
+      const organisation = document.querySelector("#id_name").value;
+      
+      // variables for checkbox
+      const checkboxes = document.querySelectorAll('input[type="checkbox"]:checked');
+      const selected = Array.from(checkboxes).map(x => x.value);
+  
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        'event': 'formSubmission',
+        'postcode': postcode,
+        'organisation': organisation,
+        'checkbox': selected,
+      });
+    });
+  </script>
+  <script nonce="{{request.csp_nonce}}">
   function tagMan() {  // Activate Google Tag Manager
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -15,7 +15,9 @@
     </style>
   {% endif %}
   <script nonce="{{request.csp_nonce}}">
-    document.querySelector('#fala_questions').addEventListener('submit', function(e){
+    const fala_form = document.querySelector('#fala_questions');
+    if (fala_form) {
+      fala_form.addEventListener('submit', function(e){
     
       // variables for postcode and organisation name
       const postcode = document.querySelector("#id_postcode").value;
@@ -33,6 +35,7 @@
         'checkbox': selected,
       });
     });
+  };
   </script>
   <script nonce="{{request.csp_nonce}}">
   function tagMan() {  // Activate Google Tag Manager

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -27,7 +27,7 @@
   
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
-        'event': 'formSubmission',
+        'event': "formSubmission",
         'postcode': postcode,
         'organisation': organisation,
         'checkbox': selected,


### PR DESCRIPTION
## What does this pull request do?

- In order to work with form input data, which is either not redacted, means we give more data to google or violates our CSP we can use [dataLayer variables](https://developers.google.com/tag-platform/tag-manager/datalayer)
- This PR therefore creates those [dataLayer variables which we can then interrogate in GA4](https://www.analyticsmania.com/post/data-layer-variable/) 

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"