### PR TITLE
EL-1447- Update when dataLayer Script is called

### DIFF
--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -15,30 +15,8 @@
     </style>
   {% endif %}
   <script nonce="{{request.csp_nonce}}">
-    const fala_form = document.querySelector('#fala_questions');
-    if (fala_form) {
-      fala_form.addEventListener('submit', function(e){
-    
-      // variables for postcode and organisation name
-      const postcode = document.querySelector("#id_postcode").value;
-      const organisation = document.querySelector("#id_name").value;
-      
-      // variables for checkbox
-      const checkboxes = document.querySelectorAll('input[type="checkbox"]:checked');
-      const selected = Array.from(checkboxes).map(x => x.value);
-  
-      window.dataLayer = window.dataLayer || [];
-      window.dataLayer.push({
-        'event': "formSubmission",
-        'postcode': postcode,
-        'organisation': organisation,
-        'checkbox': selected,
-      });
-    });
-  };
-  </script>
-  <script nonce="{{request.csp_nonce}}">
   function tagMan() {  // Activate Google Tag Manager
+    window.dataLayer = window.dataLayer || [];
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -208,5 +186,27 @@
       document.getElementById(s).scrollIntoView();
       document.getElementById(f).focus();
     }
+  </script>
+  <script nonce="{{request.csp_nonce}}">
+    const fala_form = document.querySelector('#fala_questions');
+    if (fala_form) {
+      fala_form.addEventListener('submit', function(e){
+    
+      // variables for postcode and organisation name
+      const postcode = document.querySelector("#id_postcode").value;
+      const organisation = document.querySelector("#id_name").value;
+      
+      // variables for checkbox
+      const checkboxes = document.querySelectorAll('input[type="checkbox"]:checked');
+      const selected = Array.from(checkboxes).map(x => x.value);
+
+      window.dataLayer.push({
+        'event': "formSubmission",
+        'postcode': postcode,
+        'organisation': organisation,
+        'checkbox': selected,
+      });
+    });
+  };
   </script>
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

- This PR updates when the dataLayer Script is called - it builds upon this [PR ](https://github.com/ministryofjustice/fala/pull/265)
- We are using dataLayer in order to get user input (i.e postcode, organisation name, checkboxes). This creates a JSON object that GA4 and TagManager can pick out, so we can use it for custom reporting. 

## Any other changes that would benefit highlighting?

This PR helps to populate the get the following Variables, Triggers & Tags in TagManager:
- Data Layer Variable - Categories clicked by User
- Data Layer Variable - Organisation entered by User
- Data Layer Variable - Postcode entered by User
- Custom Event - formSubmission
- GA4 event - form_submission

Best way to review that this PR is populating the above is to:
- Pull down this branch.
- Run the branch in a local server on your machine.
- Enter the preview/debug mode in Google Tag Manger
![Screenshot 2024-05-31 at 14 28 19](https://github.com/ministryofjustice/fala/assets/76905544/804d544b-8303-4c25-b623-66ce2a7ec5dd)
- Connect Tag Manager to local server on your machine. 
![Screenshot 2024-05-31 at 14 29 03](https://github.com/ministryofjustice/fala/assets/76905544/0a7c0bb1-abf4-41e8-820c-583aef4b9978)
- Verify that the `GA4 event - form_submission` tag has fired any time the form is submitted (regardless of errors)
![Screenshot 2024-05-31 at 14 30 37](https://github.com/ministryofjustice/fala/assets/76905544/c9850c3c-30a4-4293-bd20-c89e739b0a24)
- Click into tag and verify that your iput's have been captured as expected
![Screenshot 2024-05-31 at 14 32 25](https://github.com/ministryofjustice/fala/assets/76905544/25f240f0-3e37-4a3e-aeb3-0bb4b412c663)
- Verify that all other tags are 'firing' as expected. 

## Checklist


- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
