### PR TITLE
rename ingress to comply with naming requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ workflows:
             - laa-fala-live-production
 
       - deploy_with_helm:
-          name: production_deploy
+          name: helm_production_deploy
           environment: production
           requires:
             - production_deploy_approval

--- a/helm_deploy/laa-fala/values/fala-production.yaml
+++ b/helm_deploy/laa-fala/values/fala-production.yaml
@@ -44,12 +44,10 @@ service:
 
 ingress:
   hosts:
-    - host: laa-fala-production.apps.live-1.cloud-platform.service.justice.gov.uk
+    - host: laa-fala-production-helm.cloud-platform.service.justice.gov.uk
       secret: false
-    - host: find-legal-advice.justice.gov.uk
-      secret: fala-tls-certificate
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: laa-fala-fala-laa-fala-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: "fala-laa-fala-laa-fala-production-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |


### PR DESCRIPTION
## What does this pull request do?

Helm prod deploy was failing due to an incorrect naming convention of the ingress. This PR fixes the name and also add a distinct name for the helm production deploy.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
