### PR TITLE
Revert "DRY up category selection, moving methods (#290)"

### DIFF
--- a/fala/apps/adviser/templatetags/adviser_extras.py
+++ b/fala/apps/adviser/templatetags/adviser_extras.py
@@ -4,7 +4,6 @@ import re
 from urllib.parse import urlparse, parse_qs, quote
 from django_jinja import library
 from jinja2 import pass_context
-from laalaa.api import PROVIDER_CATEGORIES
 
 
 @library.filter
@@ -54,27 +53,3 @@ def google_map_params(item):
         return {"api": 1, "query": address}
     else:
         return {"api": 1, "query": postcode}
-
-
-@library.filter
-def category_tuples(form):
-    # create list of tuples which can be passed to urlencode for pagination links
-    return [("categories", c) for c in form.cleaned_data["categories"]]
-
-
-@library.filter
-def category_selection(form):
-    if "categories" in form.cleaned_data:
-        categories = [PROVIDER_CATEGORIES[cat] for cat in form.cleaned_data["categories"]]
-        formatted_categories = ", ".join(map(str, categories))
-
-        return formatted_categories
-    return None
-
-
-@library.filter
-def category_selection_list(form):
-    if "categories" in form.cleaned_data:
-        categories = [PROVIDER_CATEGORIES[cat] for cat in form.cleaned_data["categories"]]
-        return map(str, categories)
-    return []

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -5,6 +5,7 @@ from django.views.generic import TemplateView, ListView
 
 from .forms import AdviserSearchForm
 from .laa_laa_paginator import LaaLaaPaginator
+from laalaa.api import PROVIDER_CATEGORIES
 from .regions import Region
 
 
@@ -82,13 +83,25 @@ class SearchView(ListView):
                 "postcode": self._form.cleaned_data["postcode"],
                 "name": self._form.cleaned_data["name"],
             }
+            # create list of tuples which can be passed to urlencode for pagination links
+            categories = [("categories", c) for c in self._form.cleaned_data["categories"]]
             return {
                 "form": self._form,
                 "data": self._data,
                 "pages": pages,
                 "params": params,
                 "FEATURE_FLAG_SURVEY_MONKEY": settings.FEATURE_FLAG_SURVEY_MONKEY,
+                "categories": categories,
+                "category_selection": self._display_category(),
             }
+
+        def _display_category(self):
+            if "categories" in self._form.cleaned_data:
+                categories = [PROVIDER_CATEGORIES[cat] for cat in self._form.cleaned_data["categories"]]
+                formatted_categories = ", ".join(map(str, categories))
+
+                return formatted_categories
+            return []
 
     class OldMapState(object):
         def __init__(self, form, current_url):

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -23,8 +23,8 @@
         {% if form.name.value() %}
           <li class="govuk-body notranslate" role="listitem" translate="no">Organisation: {{ form.name.value() }}</li>
         {% endif %}
-        {% if form|category_selection %}
-          <li class="govuk-body notranslate" role="listitem" translate="no">Categories: {{ form|category_selection }} </li>
+        {% if category_selection %}
+          <li class="govuk-body notranslate" role="listitem" translate="no">Categories: {{ category_selection }} </li>
         {% endif %}
       </ul>
 
@@ -32,7 +32,7 @@
         <input type="hidden" name="postcode" value="{{ form.postcode.value() }}">
         <input type="hidden" name="name" value="{{ form.name.value() }}">
         {% for value, label_text in form.categories.field.choices %}
-          {% if label_text in form|category_selection_list %}
+          {% if label_text in category_selection.split(", ") %}
             <input type="hidden" name="categories" value="{{ value }}">
           {% endif %}
         {% endfor %}
@@ -112,7 +112,7 @@
         {% if current_page.has_previous() %}
           <div class="govuk-pagination__prev">
             {% if categories|length %}
-              <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ current_page.previous_page_number() }}&{{ params|urlencode }}&{{ form|category_tuples|urlencode }}" rel="prev">
+              <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ current_page.previous_page_number() }}&{{ params|urlencode }}&{{ categories|urlencode }}" rel="prev">
             {% else %}
               <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ current_page.previous_page_number() }}&{{ params|urlencode }}" rel="prev">
             {% endif %}


### PR DESCRIPTION
This reverts commit 732a8f0ba62f71e9fa97a36515ba8b8ece88f3bb.

## What does this pull request do?

This reverts the bug with the page links losing the category search behaviour

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
