### PR TITLE
EL-1627: Refactor category methods, without breaking pagination links

### DIFF
--- a/fala/apps/adviser/templatetags/adviser_extras.py
+++ b/fala/apps/adviser/templatetags/adviser_extras.py
@@ -4,6 +4,7 @@ import re
 from urllib.parse import urlparse, parse_qs, quote
 from django_jinja import library
 from jinja2 import pass_context
+from laalaa.api import PROVIDER_CATEGORIES
 
 
 @library.filter
@@ -53,3 +54,27 @@ def google_map_params(item):
         return {"api": 1, "query": address}
     else:
         return {"api": 1, "query": postcode}
+
+
+@library.filter
+def category_tuples(form):
+    # create list of tuples which can be passed to urlencode for pagination links
+    return [("categories", c) for c in form.cleaned_data["categories"]]
+
+
+@library.filter
+def category_selection(form):
+    if "categories" in form.cleaned_data:
+        categories = [PROVIDER_CATEGORIES[cat] for cat in form.cleaned_data["categories"]]
+        formatted_categories = ", ".join(map(str, categories))
+
+        return formatted_categories
+    return None
+
+
+@library.filter
+def category_selection_list(form):
+    if "categories" in form.cleaned_data:
+        categories = [PROVIDER_CATEGORIES[cat] for cat in form.cleaned_data["categories"]]
+        return map(str, categories)
+    return []

--- a/fala/apps/adviser/tests/test_search_view_function.py
+++ b/fala/apps/adviser/tests/test_search_view_function.py
@@ -67,31 +67,55 @@ class PaginationTest(SimpleTestCase):
     client = Client()
     url = reverse("search")
 
-    data = {"postcode": "PE30", "categories": "deb", "page": "2"}
-
     def test_prev_pagination_link_contains_category(self):
-        response = self.client.get(self.url, self.data)
+        data = {"postcode": "PE30", "categories": "deb", "page": "2"}
+
+        response = self.client.get(self.url, data)
         soup = bs4.BeautifulSoup(response.content, "html.parser")
         next = soup.find("div", class_="govuk-pagination__prev")
         link = next.find("a").get("href")
         self.assertEqual("/search?page=1&postcode=PE30&name=&categories=deb", link)
 
+    def test_prev_pagination_link_with_multiple_categories(self):
+        data = {"postcode": "PE30", "categories": ["deb", "aap"], "page": "2"}
+
+        response = self.client.get(self.url, data)
+        soup = bs4.BeautifulSoup(response.content, "html.parser")
+        next = soup.find("div", class_="govuk-pagination__prev")
+        link = next.find("a").get("href")
+        self.assertEqual("/search?page=1&postcode=PE30&name=&categories=deb&categories=aap", link)
+
+    def test_pagination_link_without_category(self):
+        data = {"postcode": "PE30", "page": "2"}
+
+        response = self.client.get(self.url, data)
+        soup = bs4.BeautifulSoup(response.content, "html.parser")
+        next = soup.find("div", class_="govuk-pagination__prev")
+        link = next.find("a").get("href")
+        self.assertEqual("/search?page=1&postcode=PE30&name=", link)
+
     def test_next_pagination_link_contains_category(self):
-        response = self.client.get(self.url, self.data)
+        data = {"postcode": "PE30", "categories": "deb", "page": "2"}
+
+        response = self.client.get(self.url, data)
         soup = bs4.BeautifulSoup(response.content, "html.parser")
         next = soup.find("div", class_="govuk-pagination__next")
         link = next.find("a").get("href")
         self.assertEqual("/search?page=3&postcode=PE30&name=&categories=deb", link)
 
     def test_2nd_pagination_link_contains_category(self):
-        response = self.client.get(self.url, self.data)
+        data = {"postcode": "PE30", "categories": "deb", "page": "2"}
+
+        response = self.client.get(self.url, data)
         soup = bs4.BeautifulSoup(response.content, "html.parser")
         next = soup.find("li", class_="govuk-pagination__item")
         link = next.find("a").get("href")
         self.assertEqual("/search?page=1&postcode=PE30&name=&categories=deb", link)
 
     def test_3nd_pagination_link_contains_category(self):
-        response = self.client.get(self.url, self.data)
+        data = {"postcode": "PE30", "categories": "deb", "page": "2"}
+
+        response = self.client.get(self.url, data)
         soup = bs4.BeautifulSoup(response.content, "html.parser")
         next = soup.findAll("li", class_="govuk-pagination__item")[2]
         link = next.find("a").get("href")

--- a/fala/apps/adviser/tests/test_search_view_function.py
+++ b/fala/apps/adviser/tests/test_search_view_function.py
@@ -74,21 +74,28 @@ class PaginationTest(SimpleTestCase):
         soup = bs4.BeautifulSoup(response.content, "html.parser")
         next = soup.find("div", class_="govuk-pagination__prev")
         link = next.find("a").get("href")
-        self.assertIn("deb", link)
+        self.assertEqual("/search?page=1&postcode=PE30&name=&categories=deb", link)
 
     def test_next_pagination_link_contains_category(self):
         response = self.client.get(self.url, self.data)
         soup = bs4.BeautifulSoup(response.content, "html.parser")
         next = soup.find("div", class_="govuk-pagination__next")
         link = next.find("a").get("href")
-        self.assertIn("deb", link)
+        self.assertEqual("/search?page=3&postcode=PE30&name=&categories=deb", link)
 
     def test_2nd_pagination_link_contains_category(self):
         response = self.client.get(self.url, self.data)
         soup = bs4.BeautifulSoup(response.content, "html.parser")
         next = soup.find("li", class_="govuk-pagination__item")
         link = next.find("a").get("href")
-        self.assertIn("deb", link)
+        self.assertEqual("/search?page=1&postcode=PE30&name=&categories=deb", link)
+
+    def test_3nd_pagination_link_contains_category(self):
+        response = self.client.get(self.url, self.data)
+        soup = bs4.BeautifulSoup(response.content, "html.parser")
+        next = soup.findAll("li", class_="govuk-pagination__item")[2]
+        link = next.find("a").get("href")
+        self.assertEqual("/search?page=3&postcode=PE30&name=&categories=deb", link)
 
 
 class ResultsPageWithJustPostcodeTest(SimpleTestCase):

--- a/fala/apps/adviser/tests/test_search_view_function.py
+++ b/fala/apps/adviser/tests/test_search_view_function.py
@@ -63,6 +63,34 @@ class ResultsPageWithBothOrgAndPostcodeTest(SimpleTestCase):
         self.assertNotContains(response, '<div class="govuk-pagination__previous">')
 
 
+class PaginationTest(SimpleTestCase):
+    client = Client()
+    url = reverse("search")
+
+    data = {"postcode": "PE30", "categories": "deb", "page": "2"}
+
+    def test_prev_pagination_link_contains_category(self):
+        response = self.client.get(self.url, self.data)
+        soup = bs4.BeautifulSoup(response.content, "html.parser")
+        next = soup.find("div", class_="govuk-pagination__prev")
+        link = next.find("a").get("href")
+        self.assertIn("deb", link)
+
+    def test_next_pagination_link_contains_category(self):
+        response = self.client.get(self.url, self.data)
+        soup = bs4.BeautifulSoup(response.content, "html.parser")
+        next = soup.find("div", class_="govuk-pagination__next")
+        link = next.find("a").get("href")
+        self.assertIn("deb", link)
+
+    def test_2nd_pagination_link_contains_category(self):
+        response = self.client.get(self.url, self.data)
+        soup = bs4.BeautifulSoup(response.content, "html.parser")
+        next = soup.find("li", class_="govuk-pagination__item")
+        link = next.find("a").get("href")
+        self.assertIn("deb", link)
+
+
 class ResultsPageWithJustPostcodeTest(SimpleTestCase):
     client = Client()
     url = reverse("search")

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -5,7 +5,6 @@ from django.views.generic import TemplateView, ListView
 
 from .forms import AdviserSearchForm
 from .laa_laa_paginator import LaaLaaPaginator
-from laalaa.api import PROVIDER_CATEGORIES
 from .regions import Region
 
 
@@ -71,25 +70,13 @@ class SearchView(ListView):
                 "postcode": self._form.cleaned_data["postcode"],
                 "name": self._form.cleaned_data["name"],
             }
-            # create list of tuples which can be passed to urlencode for pagination links
-            categories = [("categories", c) for c in self._form.cleaned_data["categories"]]
             return {
                 "form": self._form,
                 "data": self._data,
                 "pages": pages,
                 "params": params,
                 "FEATURE_FLAG_SURVEY_MONKEY": settings.FEATURE_FLAG_SURVEY_MONKEY,
-                "categories": categories,
-                "category_selection": self._display_category(),
             }
-
-        def _display_category(self):
-            if "categories" in self._form.cleaned_data:
-                categories = [PROVIDER_CATEGORIES[cat] for cat in self._form.cleaned_data["categories"]]
-                formatted_categories = ", ".join(map(str, categories))
-
-                return formatted_categories
-            return []
 
     class OldMapState(object):
         def __init__(self, form, current_url):

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -22,8 +22,8 @@
         {% if form.name.value() %}
           <li class="govuk-body notranslate" role="listitem" translate="no">Organisation: {{ form.name.value() }}</li>
         {% endif %}
-        {% if category_selection %}
-          <li class="govuk-body notranslate" role="listitem" translate="no">Categories: {{ category_selection }} </li>
+        {% if form|category_selection %}
+          <li class="govuk-body notranslate" role="listitem" translate="no">Categories: {{ form|category_selection }} </li>
         {% endif %}
       </ul>
 
@@ -31,7 +31,7 @@
         <input type="hidden" name="postcode" value="{{ form.postcode.value() }}">
         <input type="hidden" name="name" value="{{ form.name.value() }}">
         {% for value, label_text in form.categories.field.choices %}
-          {% if label_text in category_selection.split(", ") %}
+          {% if label_text in form|category_selection_list %}
             <input type="hidden" name="categories" value="{{ value }}">
           {% endif %}
         {% endfor %}
@@ -110,8 +110,8 @@
         {% set current_page = pages.current_page() %}
         {% if current_page.has_previous() %}
           <div class="govuk-pagination__prev">
-            {% if categories|length %}
-              <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ current_page.previous_page_number() }}&{{ params|urlencode }}&{{ categories|urlencode }}" rel="prev">
+            {% if form|category_tuples|length %}
+              <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ current_page.previous_page_number() }}&{{ params|urlencode }}&{{ form|category_tuples|urlencode }}" rel="prev">
             {% else %}
               <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ current_page.previous_page_number() }}&{{ params|urlencode }}" rel="prev">
             {% endif %}
@@ -131,8 +131,8 @@
             {% else %}
             <li class="govuk-pagination__item">
             {% endif %}
-              {% if categories|length %}
-              <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ page_num }}&{{ params|urlencode }}&{{ categories|urlencode }}" aria-label="Page {{ page_num }}" aria-current="page">
+              {% if form|category_tuples|length %}
+              <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ page_num }}&{{ params|urlencode }}&{{ form|category_tuples|urlencode }}" aria-label="Page {{ page_num }}" aria-current="page">
               {% else %}
               <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ page_num }}&{{ params|urlencode }}" aria-label="Page {{ page_num }}" aria-current="page">
               {% endif %}
@@ -143,8 +143,8 @@
         </ul>
         {% if current_page.has_next() %}
           <div class="govuk-pagination__next">
-             {% if categories|length %}
-              <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ current_page.next_page_number() }}&{{ params|urlencode }}&{{ categories|urlencode }}" rel="next">
+             {% if form|category_tuples|length %}
+              <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ current_page.next_page_number() }}&{{ params|urlencode }}&{{ form|category_tuples|urlencode }}" rel="next">
              {% else %}
               <a class="govuk-link govuk-pagination__link" href="{{ url('search') }}?page={{ current_page.next_page_number() }}&{{ params|urlencode }}" rel="next">
              {% endif %}


### PR DESCRIPTION
## What does this pull request do?

Fix bug - pagination links pointed at non-category search always (even on a category search) so second and subsequent pages displayed non-filtered information

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
