### PR TITLE
EL-1619: Set UAT deploy workflow to only run on branches and not main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,13 +236,13 @@ workflows:
           environment: staging
           requires:
             - build
-          context:
-            - laa-fala
-            - laa-fala-live-staging
           filters:
             branches:
               ignore:
                 - main
+          context:
+            - laa-fala
+            - laa-fala-live-staging
 
       - staging_deploy_approval:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,10 @@ workflows:
           context:
             - laa-fala
             - laa-fala-live-staging
+          filters:
+            branches:
+              ignore:
+                - main
 
       - staging_deploy_approval:
           type: approval


### PR DESCRIPTION
## What does this pull request do?

UAT job is deploying to staging on main. Stop this from happening.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
