### PR TITLE
EL-1626: Translating postcode, organisation & categories fields in grey box on results page

### DIFF
--- a/fala/apps/adviser/tests/page_objects.py
+++ b/fala/apps/adviser/tests/page_objects.py
@@ -39,7 +39,7 @@ class ResultsPage(FalaPage):
 
     @property
     def change_search_grey_box(self):
-        return self._page.locator("li.govuk-body.notranslate")
+        return self._page.locator("li.govuk-body")
 
 
 class OtherRegionPage(FalaPage):

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -17,13 +17,13 @@
     <div class="laa-fala__grey-box govuk-!-margin-bottom-6">
       <ul class="govuk-list" role="list">
         {% if form.postcode.value() %}
-          <li class="govuk-body notranslate" role="listitem" translate="no">Postcode: {{ form.postcode.value() }}</li>
+          <li class="govuk-body" role="listitem">Postcode:<span class="notranslate"> {{ form.postcode.value() }}</span></li>
         {% endif %}
         {% if form.name.value() %}
-          <li class="govuk-body notranslate" role="listitem" translate="no">Organisation: {{ form.name.value() }}</li>
+          <li class="govuk-body" role="listitem">Organisation:<span class="notranslate"> {{ form.name.value() }}</span></li>
         {% endif %}
         {% if form|category_selection %}
-          <li class="govuk-body notranslate" role="listitem" translate="no">Categories: {{ form|category_selection }} </li>
+          <li class="govuk-body" role="listitem">Categories: {{ form|category_selection }} </li>
         {% endif %}
       </ul>
 


### PR DESCRIPTION
## What does this pull request do?

- translating postcode, organisation & categories fields in grey box on results page

## Any other changes that would benefit highlighting?

- not translating what the user input on search screen

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
