### PR TITLE
EL-1684: Fix flakey pagination test

### DIFF
--- a/fala/apps/adviser/tests/page_objects.py
+++ b/fala/apps/adviser/tests/page_objects.py
@@ -41,6 +41,10 @@ class ResultsPage(FalaPage):
     def change_search_grey_box(self):
         return self._page.locator("li.govuk-body")
 
+    @property
+    def result_count(self):
+        return self._page.locator("#result-count-overall")
+
 
 class OtherRegionPage(FalaPage):
     pass

--- a/fala/apps/adviser/tests/test_pagination_playwright.py
+++ b/fala/apps/adviser/tests/test_pagination_playwright.py
@@ -8,12 +8,14 @@ class PaginationResults(PlaywrightTestSetup):
         checkboxes = ["Crime"]
 
         page = self.visit_results_page("M25 3JF", checkboxes)
-        expect(page.item_from_text("1576 results in order of closeness to M25 3JF.")).to_be_visible()
+        expect(page.item_from_text("results in order of closeness to M25 3JF.")).to_be_visible()
+        first_page_result_count = page.result_count.inner_text()
         expect(page.pagination_link_title).to_be_visible()
         page.next_link.click()
-        # this tests that changing page persists the category choice by not affecting the result count
-        expect(page.item_from_text("1576 results in order of closeness to M25 3JF.")).to_be_visible()
+        # expect the result count of page 2 to match page 1.
+        # then we know the filters are still applied.
+        expect(page.result_count).to_have_text(first_page_result_count)
         page.select_page_number(4).click()
-        expect(page.item_from_text("1576 results in order of closeness to M25 3JF.")).to_be_visible()
+        expect(page.result_count).to_have_text(first_page_result_count)
         page.previous_link.click()
-        expect(page.item_from_text("1576 results in order of closeness to M25 3JF.")).to_be_visible()
+        expect(page.result_count).to_have_text(first_page_result_count)

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -43,7 +43,7 @@
       {% if data.origin %}
         {% trans page_count=data.results|length, result_count=data.count %}
           {% pluralize %}
-          <span class="govuk-!-font-weight-bold">{{ result_count }} results</span> in order of closeness to
+          <span class="govuk-!-font-weight-bold" id="result-count-overall">{{ result_count }} results</span> in order of closeness to
         {% endtrans %}
         <strong class="notranslate" translate="no">{{ form.postcode.value()|upper }}</strong>
         {%- if form.name.value() %}
@@ -54,7 +54,7 @@
       {% else %}
         {% trans result_count=data.count, page_count=data.results|length, org_name=form.name.value() %}
           {% pluralize %}
-          <span class="govuk-!-font-weight-bold">{{ result_count }} results</span> for <strong>{{ org_name }}</strong>.
+          <span class="govuk-!-font-weight-bold" id="result-count-org">{{ result_count }} results</span> for <strong>{{ org_name }}</strong>.
         {% endtrans %}
       {% endif %}
       </span>


### PR DESCRIPTION
## What does this pull request do?

Fix flakey test where we were using result count to deduce if the filters remained applied correctly.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
