### PR TITLE
Create a new browser context for each test

### DIFF
--- a/fala/playwright/setup.py
+++ b/fala/playwright/setup.py
@@ -9,14 +9,22 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
     def setUpClass(cls):
         os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
         super().setUpClass()
-        cls.playwright = sync_playwright().start()
-        cls.browser = cls.playwright.chromium.launch()
+        cls._playwright = sync_playwright().start()
+        cls._factory = cls._playwright.chromium.launch()
 
     @classmethod
     def tearDownClass(cls):
+        cls._factory.close()
+        cls._playwright.stop()
         super().tearDownClass()
-        cls.browser.close()
-        cls.playwright.stop()
+
+    def setUp(self):
+        super().setUp()
+        self.browser = self._factory.new_context()
+
+    def tearDown(self):
+        self.browser.close()
+        super().tearDown()
 
     def visit_results_page(self, postcode, checkbox_labels=None):
         if checkbox_labels is None:


### PR DESCRIPTION
## What does this pull request do?

Create a new browser context for each test. Turns out we were not using Playwright correctly for multi-page scenarios, as the 'browser' object was actually a shortcut, so that browser.new_page() called browser.new_context().new_page() which creates issues when wanting to check state between pages (specifically cookies) 

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
