### PR TITLE
EL-1561 Sort FALA categories by name not by abbreviation code

### DIFF
--- a/fala/apps/laalaa/api.py
+++ b/fala/apps/laalaa/api.py
@@ -17,7 +17,8 @@ except NameError:
 def get_categories():
     if settings.LAALAA_API_HOST:
         categories = LaalaaProviderCategoriesApiClient.singleton(settings.LAALAA_API_HOST, _).get_categories()
-        return [item for item in sorted(categories.items())]
+        # sort by name (the second item in the tuple) rather than the code
+        return [item for item in sorted(categories.items(), key=lambda x: x[1])]
 
     return []
 


### PR DESCRIPTION
## What does this pull request do?

Sort FALA categories by name not by abbreviation code

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
