### PR TITLE
EL-1507: Pre-populated-url

### DIFF
--- a/docs/virtual-env.md
+++ b/docs/virtual-env.md
@@ -172,3 +172,4 @@ To run them manually:
 ```
 pre-commit run --all-files
 ```
+

--- a/docs/virtual-env.md
+++ b/docs/virtual-env.md
@@ -172,4 +172,3 @@ To run them manually:
 ```
 pre-commit run --all-files
 ```
-

--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -35,7 +35,9 @@ class CapitalisedPostcodeField(forms.CharField):
         return super().to_python(capitalised_value)
 
 
-# This is so that we can hit the front page with query parameters in url and not see validation errors
+# This is so that we can hit the front page with query parameters in url and not see form validation errors
+# In django, form validation happens when the data is cleaned, i.e. form validation, form errors, form cleaned
+# `def clean(self)` is the method triggering form validation, so have abstracted that into `AdviserSearchForm` form class
 class AdviserRootForm(forms.Form):
     postcode = CapitalisedPostcodeField(
         label=_("Postcode"),

--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -37,7 +37,7 @@ class CapitalisedPostcodeField(forms.CharField):
 
 # This is so that we can hit the front page with query parameters in url and not see form validation errors
 # In django, form validation happens when the data is cleaned, i.e. form validation, form errors, form cleaned
-# `def clean(self)` is the method triggering form validation, so have abstracted that into `AdviserSearchForm` form class
+# `def clean(self)` is the method triggering form validation, so have extracted that into `AdviserSearchForm` form class
 class AdviserRootForm(forms.Form):
     postcode = CapitalisedPostcodeField(
         label=_("Postcode"),

--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -35,9 +35,8 @@ class CapitalisedPostcodeField(forms.CharField):
         return super().to_python(capitalised_value)
 
 
-class AdviserSearchForm(forms.Form):
-    page = forms.IntegerField(required=False, widget=forms.HiddenInput())
-
+# This is so that we can hit the front page with query parameters in url and not see validation errors
+class AdviserRootForm(forms.Form):
     postcode = CapitalisedPostcodeField(
         label=_("Postcode"),
         max_length=30,
@@ -53,13 +52,6 @@ class AdviserSearchForm(forms.Form):
         widget=FalaTextInput(),
     )
 
-    type = forms.MultipleChoiceField(
-        label=_("Organisation type"),
-        choices=ORGANISATION_TYPES_CHOICES,
-        widget=forms.CheckboxSelectMultiple(),
-        required=False,
-    )
-
     categories = forms.MultipleChoiceField(
         label=_("Category"),
         choices=laalaa.PROVIDER_CATEGORY_CHOICES,
@@ -67,9 +59,13 @@ class AdviserSearchForm(forms.Form):
         required=False,
     )
 
+
+class AdviserSearchForm(AdviserRootForm):
+    page = forms.IntegerField(required=False, widget=forms.HiddenInput())
+
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("label_suffix", "")
-        super(AdviserSearchForm, self).__init__(*args, **kwargs)
+        super(AdviserRootForm, self).__init__(*args, **kwargs)
 
     def clean(self):
         data = self.cleaned_data

--- a/fala/apps/adviser/tests/page_objects.py
+++ b/fala/apps/adviser/tests/page_objects.py
@@ -7,6 +7,10 @@ class FalaPage(object):
         return self._page.locator("h1")
 
     @property
+    def error_list(self):
+        return self._page.get_by_text("There is a problem")
+
+    @property
     def language_dropdown(self):
         return self._page.locator('select[class="goog-te-combo"]')
 

--- a/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
+++ b/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
@@ -14,15 +14,18 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
         expect(page.checkbox_by_label("Housing Loss Prevention Advice Service")).to_be_checked()
 
     def test_landing_page_with_multiple_url_params(self):
+        hlpas = "Housing Loss Prevention Advice Service"
+        edu = "Education"
         page = self.visit_search_page_with_url_params("categories=hlpas&categories=edu")
         expect(page.h1).to_have_text("Find a legal aid adviser or family mediator")
         expect(page.error_list).not_to_be_visible()
-        expect(page.checkbox_by_label("Housing Loss Prevention Advice Service")).to_be_checked()
-        expect(page.checkbox_by_label("Education")).to_be_checked()
+        expect(page.checkbox_by_label(f"{hlpas}")).to_be_checked()
+        expect(page.checkbox_by_label(f"{edu}")).to_be_checked()
+        # we are reloading the page, as we wanted to verify that we would be presented with the same view
         page._page.reload()
         expect(page.error_list).not_to_be_visible()
-        expect(page.checkbox_by_label("Housing Loss Prevention Advice Service")).to_be_checked()
-        expect(page.checkbox_by_label("Education")).to_be_checked()
+        expect(page.checkbox_by_label(f"{hlpas}")).to_be_checked()
+        expect(page.checkbox_by_label(f"{edu}")).to_be_checked()
 
     def test_postcode_search_journey(self):
         test_cases = [

--- a/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
+++ b/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
@@ -3,29 +3,31 @@ from fala.playwright.setup import PlaywrightTestSetup
 
 
 class SearchPageEndToEndJourneys(PlaywrightTestSetup):
+    hlpas = "Housing Loss Prevention Advice Service"
+    edu = "Education"
+    front_page_heading = "Find a legal aid adviser or family mediator"
+
     def test_landing_page(self):
         page = self.visit_search_page()
-        expect(page.h1).to_have_text("Find a legal aid adviser or family mediator")
+        expect(page.h1).to_have_text(f"{self.front_page_heading}")
 
     def test_landing_page_with_url_params(self):
         page = self.visit_search_page_with_url_params("categories=hlpas")
-        expect(page.h1).to_have_text("Find a legal aid adviser or family mediator")
+        expect(page.h1).to_have_text(f"{self.front_page_heading}")
         expect(page.error_list).not_to_be_visible()
-        expect(page.checkbox_by_label("Housing Loss Prevention Advice Service")).to_be_checked()
+        expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
 
     def test_landing_page_with_multiple_url_params(self):
-        hlpas = "Housing Loss Prevention Advice Service"
-        edu = "Education"
         page = self.visit_search_page_with_url_params("categories=hlpas&categories=edu")
-        expect(page.h1).to_have_text("Find a legal aid adviser or family mediator")
+        expect(page.h1).to_have_text(f"{self.front_page_heading}")
         expect(page.error_list).not_to_be_visible()
-        expect(page.checkbox_by_label(f"{hlpas}")).to_be_checked()
-        expect(page.checkbox_by_label(f"{edu}")).to_be_checked()
+        expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
+        expect(page.checkbox_by_label(f"{self.edu}")).to_be_checked()
         # we are reloading the page, as we wanted to verify that we would be presented with the same view
         page._page.reload()
         expect(page.error_list).not_to_be_visible()
-        expect(page.checkbox_by_label(f"{hlpas}")).to_be_checked()
-        expect(page.checkbox_by_label(f"{edu}")).to_be_checked()
+        expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
+        expect(page.checkbox_by_label(f"{self.edu}")).to_be_checked()
 
     def test_postcode_search_journey(self):
         test_cases = [
@@ -52,7 +54,7 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
     def test_invalid_organisation_search(self):
         page = self.browser.new_page()
         page.goto(f"{self.live_server_url}")
-        expect(page.locator("h1")).to_have_text("Find a legal aid adviser or family mediator")
+        expect(page.locator("h1")).to_have_text(f"{self.front_page_heading}")
         page.get_by_label("Organisation name").fill("test")
         page.get_by_role("button", name="Search").click()
         expect(page.locator("h1")).to_have_text("Search results")
@@ -61,8 +63,8 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
     def test_invalid_postcode_journey(self):
         page = self.browser.new_page()
         page.goto(f"{self.live_server_url}")
-        expect(page.locator("h1")).to_have_text("Find a legal aid adviser or family mediator")
+        expect(page.locator("h1")).to_have_text(f"{self.front_page_heading}")
         page.get_by_label("Postcode").fill("ZZZ1")
         page.get_by_role("button", name="Search").click()
-        expect(page.locator("h1")).to_have_text("Find a legal aid adviser or family mediator")
+        expect(page.locator("h1")).to_have_text(f"{self.front_page_heading}")
         expect(page.locator("css=.govuk-error-summary")).to_be_visible()

--- a/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
+++ b/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
@@ -7,6 +7,23 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
         page = self.visit_search_page()
         expect(page.h1).to_have_text("Find a legal aid adviser or family mediator")
 
+    def test_landing_page_with_url_params(self):
+        page = self.visit_search_page_with_url_params("categories=hlpas")
+        expect(page.h1).to_have_text("Find a legal aid adviser or family mediator")
+        expect(page.error_list).not_to_be_visible()
+        expect(page.checkbox_by_label("Housing Loss Prevention Advice Service")).to_be_checked()
+
+    def test_landing_page_with_multiple_url_params(self):
+        page = self.visit_search_page_with_url_params("categories=hlpas&categories=edu")
+        expect(page.h1).to_have_text("Find a legal aid adviser or family mediator")
+        expect(page.error_list).not_to_be_visible()
+        expect(page.checkbox_by_label("Housing Loss Prevention Advice Service")).to_be_checked()
+        expect(page.checkbox_by_label("Education")).to_be_checked()
+        page._page.reload()
+        expect(page.error_list).not_to_be_visible()
+        expect(page.checkbox_by_label("Housing Loss Prevention Advice Service")).to_be_checked()
+        expect(page.checkbox_by_label("Education")).to_be_checked()
+
     def test_postcode_search_journey(self):
         test_cases = [
             "SW1H 9AJ",

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.urls import resolve, reverse
 from django.views.generic import TemplateView, ListView
 
-from .forms import AdviserSearchForm
+from .forms import AdviserSearchForm, AdviserRootForm
 from .laa_laa_paginator import LaaLaaPaginator
 from .regions import Region
 
@@ -15,14 +15,14 @@ class AdviserView(TemplateView):
 
     def get(self, request, *args, **kwargs):
         context = self.get_context_data(**kwargs)
-        form = AdviserSearchForm(data=request.GET or None)
+        form = AdviserRootForm(data=request.GET or None)
         view_name = resolve(request.path_info).url_name
         current_url = reverse(view_name)
 
         context.update(
             {
                 "form": form,
-                "data": form.search(),
+                "data": {},
                 "errorList": [],
                 "current_url": current_url,
                 "CHECK_LEGAL_AID_URL": settings.CHECK_LEGAL_AID_URL,
@@ -182,6 +182,7 @@ class SearchView(ListView):
 
     def get(self, request, *args, **kwargs):
         form = AdviserSearchForm(data=request.GET or None)
+
         if form.is_valid():
             region = form.region
             if region == Region.ENGLAND_OR_WALES or region == Region.SCOTLAND:

--- a/fala/playwright/setup.py
+++ b/fala/playwright/setup.py
@@ -53,6 +53,11 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
         else:
             return OtherRegionPage(page)
 
+    def visit_search_page_with_url_params(self, url_params):
+        page = self.browser.new_page()
+        page.goto(f"{self.live_server_url}/?{url_params}")
+        return SearchPage(page)
+
     def visit_search_page(self):
         page = self.browser.new_page()
         page.goto(f"{self.live_server_url}")


### PR DESCRIPTION
## What does this pull request do?

- form validation happens when the data is cleaned, i.e. form validation, form errors, form cleaned
- `def clean(self)` is the method triggering form validation, so have abstracted that into `AdviserSearchForm` form class

## Any other changes that would benefit highlighting?

- have not made the form do a post, as suggested by the ticket, as this would not be feasible to do

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
