### PR TITLE
EL-1697 use branch hash in ECR tag name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,11 @@ commands:
           role_arn: $ECR_ROLE_TO_ASSUME # this will use the env var
           region: $ECR_REGION # this will use the env var
       - run:
-          name: Create target tags
+          name: Set ECR_TAG environment variable for use in next step
           command: |
-            source .circleci/define_build_environment_variables
-            echo "Created tags $TARGET_TAGS"
-            echo "export BUILD_TAGS=$TARGET_TAGS" >> $BASH_ENV
-            echo "export IMAGE_TAG=$IMAGE_TAG" >> $BASH_ENV
+            [[ "$CIRCLE_BRANCH" == "main" ]] && ECR_TAG="main-$CIRCLE_SHA1" || ECR_TAG="branch-$CIRCLE_SHA1"
+            echo "export ECR_TAG=$ECR_TAG" >> "$BASH_ENV"
+            source "$BASH_ENV"
       # Authenticate to the ECR repository using the standard command
       - run: |
           aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com
@@ -129,7 +128,7 @@ jobs:
           no_output_timeout: 15m
           push_image: true
           account_id: $AWS_ECR_REGISTRY_ID
-          tag: $BUILD_TAGS
+          tag: $ECR_TAG
           region: $ECR_REGION # this will use the env var
           repo: $ECR_REPOSITORY # this will use the env var
           extra_build_args: |
@@ -138,7 +137,7 @@ jobs:
       - run:
           name: Validate Python version
           command: |
-            docker run --rm --tty --interactive ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/$ECR_REPOSITORY:$IMAGE_TAG python --version | grep "3.12"
+            docker run --rm --tty --interactive ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/$ECR_REPOSITORY:$ECR_TAG python --version | grep "3.12"
 
   deploy_grafana:
     docker:

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -7,7 +7,7 @@ BRANCH_RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:
 deploy_branch() {
 # Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main
   RELEASE_HOST="$BRANCH_RELEASE_NAME-fala-staging.cloud-platform.service.justice.gov.uk"
-# Set the ingress name, needs <release name>-<chart name>-<namespace>-green 
+# Set the ingress name, needs <release name>-<chart name>-<namespace>-green
   IDENTIFIER="$BRANCH_RELEASE_NAME-laa-fala-$K8S_NAMESPACE-green"
   echo "this is the identifer ingress name $IDENTIFIER"
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$BRANCH_RELEASE_NAME'..."
@@ -17,7 +17,7 @@ deploy_branch() {
                 --namespace=${K8S_NAMESPACE} \
                 --values ./helm_deploy/laa-fala/values/fala-uat.yaml \
                 --set image.repository="$ECR_ENDPOINT" \
-                --set image.tag="$IMAGE_TAG" \
+                --set image.tag="branch-$CIRCLE_SHA1" \
                 --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER" \
                 --set ingress.hosts[0].host="$RELEASE_HOST"
 }
@@ -28,7 +28,7 @@ deploy_main() {
                           --namespace=${K8S_NAMESPACE} \
                           --values ./helm_deploy/laa-fala/values/fala-$ENVIRONMENT.yaml \
                           --set image.repository="${ECR_ENDPOINT}" \
-                          --set image.tag="$CIRCLE_SHA1"
+                          --set image.tag="main-$CIRCLE_SHA1"
 }
 
 


### PR DESCRIPTION
## What does this pull request do?

use branch hash in ECR tag name to prevent wrong tag being used during UAT. Doesn't work with production k8s deployment, but that is now unused

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
