### PR TITLE
EL-1640 Removing delete pvc command. Not required

### DIFF
--- a/.github/actions/delete-uat-release/action.yml
+++ b/.github/actions/delete-uat-release/action.yml
@@ -84,7 +84,6 @@ runs:
         if [[ ! -z "$found" ]]
         then
           helm delete $release_name
-          kubectl delete pvc data-$release_name-postgresql-0
           echo "message=\"Deleted UAT release ${release_name}\"" >> $GITHUB_OUTPUT
         else
           echo "message=\"UAT release, ${release_name}, not found\"" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What does this pull request do?

Removing delete command for PVC. No longer needed as we now use Helm Deploy. Will remove errors after every PR merge going forward.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

-[El-1640](https://dsdmoj.atlassian.net/browse/EL-1640)