### PR TITLE
EL-1716 remove certificate

### DIFF
--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -14,7 +14,6 @@ spec:
   tls:
   - hosts:
     - laa-fala-production-old.apps.live-1.cloud-platform.service.justice.gov.uk
-    secretName: fala-tls-certificate
   rules:
   - host: laa-fala-production-old.apps.live-1.cloud-platform.service.justice.gov.uk
     http:


### PR DESCRIPTION
## What does this pull request do?

removes the cert from the k8s deploy as it is not valid for the host name we use here

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

-[El-1716](https://dsdmoj.atlassian.net/browse/EL-1716)
