### PR TITLE
EL-1709: Playwright screenshots on test fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,9 @@ jobs:
             DB_NAME: test
             DB_USER: postgres
             DB_HOST: localhost
+      - store_artifacts:
+          path: ./fala/playwright/screenshots
+          destination: /tmp/artifacts
 
   build:
     executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ fala/assets
 fala/static
 .cache
 .bash_history
+fala/playwright/screenshots
 
 # Python version on local machine
 .python-version

--- a/fala/apps/adviser/tests/test_cookies_page_journeys_playwright.py
+++ b/fala/apps/adviser/tests/test_cookies_page_journeys_playwright.py
@@ -7,14 +7,24 @@ import datetime
 
 class CookiesPageEndToEndJourneys(PlaywrightTestSetup):
     def test_cookies_page_view_accessed_from_footer(self):
-        page = self.visit_cookies_page_from_footer()
-        expect(page.h1).to_have_text("Cookies")
-        self.test_failed_take_screenshot = False
+        try:
+            page = self.visit_cookies_page_from_footer()
+            expect(page.h1).to_have_text("Cookies")
+            self.test_failed_take_screenshot = False
+
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
     def test_cookies_page_view_accessed_from_banner(self):
-        page = self.visit_cookies_page_from_banner()
-        expect(page.h1).to_have_text("Cookies")
-        self.test_failed_take_screenshot = False
+        try:
+            page = self.visit_cookies_page_from_banner()
+            expect(page.h1).to_have_text("Cookies")
+            self.test_failed_take_screenshot = False
+
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
 
 class CookiesPageEndToEndJourneysWithFreshSetUp(StaticLiveServerTestCase):

--- a/fala/apps/adviser/tests/test_other_regions_playwright.py
+++ b/fala/apps/adviser/tests/test_other_regions_playwright.py
@@ -4,24 +4,30 @@ from fala.playwright.setup import PlaywrightTestSetup
 
 class OtherRegionsTest(PlaywrightTestSetup):
     def test_jersey(self):
-        results_page = self.visit_results_page("JE1")
-        expect(results_page.h1).to_have_text("The postcode JE1 is in Jersey")
-        search_page = results_page.change_search()
-        # We don't preserve Jersey postcodes search term, by design, as we don't want residents from Jersey to use our service
-        expect(search_page.item_from_text("Organisation name")).to_be_visible()
+        try:
+            results_page = self.visit_results_page("JE1")
+            expect(results_page.h1).to_have_text("The postcode JE1 is in Jersey")
+            search_page = results_page.change_search()
+            # We don't preserve Jersey postcodes search term, by design, as we don't want residents from Jersey to use our service
+            expect(search_page.item_from_text("Organisation name")).to_be_visible()
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
     def test_scotland_with_persistant_search_and_categories(self):
-        checkboxes = ["Family mediation", "Clinical Negligence"]
+        try:
+            checkboxes = ["Family mediation", "Clinical Negligence"]
 
-        results_page = self.visit_results_page("TD13", checkboxes)
-        expect(results_page.item_from_text("Legal Aid in Scotland")).to_be_visible()
-        search_page = results_page.change_search()
+            results_page = self.visit_results_page("TD13", checkboxes)
+            expect(results_page.item_from_text("Legal Aid in Scotland")).to_be_visible()
+            search_page = results_page.change_search()
 
-        # after switching back to the change search page, postcode and checkboxes are preserved
-        expect(search_page.postcode_input_field).to_have_value("TD13")
-        for checkbox in checkboxes:
-            expect(search_page.checkbox_by_label(checkbox)).to_be_checked()
+            # after switching back to the change search page, postcode and checkboxes are preserved
+            expect(search_page.postcode_input_field).to_have_value("TD13")
+            for checkbox in checkboxes:
+                expect(search_page.checkbox_by_label(checkbox)).to_be_checked()
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e

--- a/fala/apps/adviser/tests/test_other_regions_playwright.py
+++ b/fala/apps/adviser/tests/test_other_regions_playwright.py
@@ -10,6 +10,8 @@ class OtherRegionsTest(PlaywrightTestSetup):
         # We don't preserve Jersey postcodes search term, by design, as we don't want residents from Jersey to use our service
         expect(search_page.item_from_text("Organisation name")).to_be_visible()
 
+        self.test_failed_take_screenshot = False
+
     def test_scotland_with_persistant_search_and_categories(self):
         checkboxes = ["Family mediation", "Clinical Negligence"]
 
@@ -21,3 +23,5 @@ class OtherRegionsTest(PlaywrightTestSetup):
         expect(search_page.postcode_input_field).to_have_value("TD13")
         for checkbox in checkboxes:
             expect(search_page.checkbox_by_label(checkbox)).to_be_checked()
+
+        self.test_failed_take_screenshot = False

--- a/fala/apps/adviser/tests/test_pagination_playwright.py
+++ b/fala/apps/adviser/tests/test_pagination_playwright.py
@@ -5,19 +5,22 @@ from fala.playwright.setup import PlaywrightTestSetup
 class PaginationResults(PlaywrightTestSetup):
 
     def test_results_pagination(self):
-        checkboxes = ["Crime"]
+        try:
+            checkboxes = ["Crime"]
 
-        page = self.visit_results_page("M25 3JF", checkboxes)
-        expect(page.item_from_text("results in order of closeness to M25 3JF.")).to_be_visible()
-        first_page_result_count = page.result_count.inner_text()
-        expect(page.pagination_link_title).to_be_visible()
-        page.next_link.click()
-        # expect the result count of page 2 to match page 1.
-        # then we know the filters are still applied.
-        expect(page.result_count).to_have_text(first_page_result_count)
-        page.select_page_number(4).click()
-        expect(page.result_count).to_have_text(first_page_result_count)
-        page.previous_link.click()
-        expect(page.result_count).to_have_text(first_page_result_count)
+            page = self.visit_results_page("M25 3JF", checkboxes)
+            expect(page.item_from_text("results in order of closeness to M25 3JF.")).to_be_visible()
+            first_page_result_count = page.result_count.inner_text()
+            expect(page.pagination_link_title).to_be_visible()
+            page.next_link.click()
+            # expect the result count of page 2 to match page 1.
+            # then we know the filters are still applied.
+            expect(page.result_count).to_have_text(first_page_result_count)
+            page.select_page_number(4).click()
+            expect(page.result_count).to_have_text(first_page_result_count)
+            page.previous_link.click()
+            expect(page.result_count).to_have_text(first_page_result_count)
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e

--- a/fala/apps/adviser/tests/test_pagination_playwright.py
+++ b/fala/apps/adviser/tests/test_pagination_playwright.py
@@ -19,3 +19,5 @@ class PaginationResults(PlaywrightTestSetup):
         expect(page.result_count).to_have_text(first_page_result_count)
         page.previous_link.click()
         expect(page.result_count).to_have_text(first_page_result_count)
+
+        self.test_failed_take_screenshot = False

--- a/fala/apps/adviser/tests/test_results_page_journeys_playwright.py
+++ b/fala/apps/adviser/tests/test_results_page_journeys_playwright.py
@@ -8,3 +8,5 @@ class ResultPageEndToEndJourneys(PlaywrightTestSetup):
         expect(results_page.change_search_grey_box).to_have_text("Postcode: SE11")
         search_page = results_page.change_search()
         expect(search_page.h1).to_have_text("Find a legal aid adviser or family mediator")
+
+        self.test_failed_take_screenshot = False

--- a/fala/apps/adviser/tests/test_results_page_journeys_playwright.py
+++ b/fala/apps/adviser/tests/test_results_page_journeys_playwright.py
@@ -4,9 +4,12 @@ from fala.playwright.setup import PlaywrightTestSetup
 
 class ResultPageEndToEndJourneys(PlaywrightTestSetup):
     def test_change_search(self):
-        results_page = self.visit_results_page("SE11")
-        expect(results_page.change_search_grey_box).to_have_text("Postcode: SE11")
-        search_page = results_page.change_search()
-        expect(search_page.h1).to_have_text("Find a legal aid adviser or family mediator")
+        try:
+            results_page = self.visit_results_page("SE11")
+            expect(results_page.change_search_grey_box).to_have_text("Postcode: SE11")
+            search_page = results_page.change_search()
+            expect(search_page.h1).to_have_text("Find a legal aid adviser or family mediator")
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e

--- a/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
+++ b/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
@@ -8,79 +8,100 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
     front_page_heading = "Find a legal aid adviser or family mediator"
 
     def test_landing_page(self):
-        page = self.visit_search_page()
-        expect(page.h1).to_have_text(f"{self.front_page_heading}")
+        try:
+            page = self.visit_search_page()
+            expect(page.h1).to_have_text(f"{self.front_page_heading}")
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
     def test_landing_page_with_url_params(self):
-        page = self.visit_search_page_with_url_params("categories=hlpas")
-        expect(page.h1).to_have_text(f"{self.front_page_heading}")
-        expect(page.error_list).not_to_be_visible()
-        expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
+        try:
+            page = self.visit_search_page_with_url_params("categories=hlpas")
+            expect(page.h1).to_have_text(f"{self.front_page_heading}")
+            expect(page.error_list).not_to_be_visible()
+            expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
     def test_landing_page_with_multiple_url_params(self):
-        page = self.visit_search_page_with_url_params("categories=hlpas&categories=edu")
-        expect(page.h1).to_have_text(f"{self.front_page_heading}")
-        expect(page.error_list).not_to_be_visible()
-        expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
-        expect(page.checkbox_by_label(f"{self.edu}")).to_be_checked()
-        # we are reloading the page, as we wanted to verify that we would be presented with the same view
-        page._page.reload()
-        expect(page.error_list).not_to_be_visible()
-        expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
-        expect(page.checkbox_by_label(f"{self.edu}")).to_be_checked()
+        try:
+            page = self.visit_search_page_with_url_params("categories=hlpas&categories=edu")
+            expect(page.h1).to_have_text(f"{self.front_page_heading}")
+            expect(page.error_list).not_to_be_visible()
+            expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
+            expect(page.checkbox_by_label(f"{self.edu}")).to_be_checked()
+            # we are reloading the page, as we wanted to verify that we would be presented with the same view
+            page._page.reload()
+            expect(page.error_list).not_to_be_visible()
+            expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
+            expect(page.checkbox_by_label(f"{self.edu}")).to_be_checked()
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
     def test_postcode_search_journey(self):
-        test_cases = [
-            "SW1H 9AJ",
-            "SE11",
-        ]
-        for postcode in test_cases:
-            with self.subTest(postcode=postcode):
-                page = self.visit_results_page(postcode)
-                expect(page.h1).to_have_text("Search results")
-                expect(page.change_search_grey_box.nth(0)).to_have_text(f"Postcode: {postcode}")
-                expect(page.item_from_text("in order of closeness")).to_be_visible()
+        try:
+            test_cases = [
+                "SW1H 9AJ",
+                "SE11",
+            ]
+            for postcode in test_cases:
+                with self.subTest(postcode=postcode):
+                    page = self.visit_results_page(postcode)
+                    expect(page.h1).to_have_text("Search results")
+                    expect(page.change_search_grey_box.nth(0)).to_have_text(f"Postcode: {postcode}")
+                    expect(page.item_from_text("in order of closeness")).to_be_visible()
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
     def test_full_search_journey(self):
-        page = self.visit_results_page_with_full_search(
-            "SE11", "Islington Law Centre", ["Housing Loss Prevention Advice Service"]
-        )
-        expect(page.h1).to_have_text("Search results")
-        # this selector matches multiple things so picking out the things we want using 'nth()'
-        expect(page.change_search_grey_box.nth(0)).to_have_text("Postcode: SE11")
-        expect(page.change_search_grey_box.nth(1)).to_have_text("Organisation: Islington Law Centre")
-        expect(page.change_search_grey_box.nth(2)).to_have_text(
-            "Legal problem: Housing Loss Prevention Advice Service"
-        )
+        try:
+            page = self.visit_results_page_with_full_search(
+                "SE11", "Islington Law Centre", ["Housing Loss Prevention Advice Service"]
+            )
+            expect(page.h1).to_have_text("Search results")
+            # this selector matches multiple things so picking out the things we want using 'nth()'
+            expect(page.change_search_grey_box.nth(0)).to_have_text("Postcode: SE11")
+            expect(page.change_search_grey_box.nth(1)).to_have_text("Organisation: Islington Law Centre")
+            expect(page.change_search_grey_box.nth(2)).to_have_text(
+                "Legal problem: Housing Loss Prevention Advice Service"
+            )
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
     def test_invalid_organisation_search(self):
-        page = self.browser.new_page()
-        page.goto(f"{self.live_server_url}")
-        expect(page.locator("h1")).to_have_text(f"{self.front_page_heading}")
-        page.get_by_label("Organisation name").fill("test")
-        page.get_by_role("button", name="Search").click()
-        expect(page.locator("h1")).to_have_text("No search results")
-        expect(page.locator("#no-results-info")).to_have_text("There are no results for your criteria.")
+        try:
+            page = self.browser.new_page()
+            page.goto(f"{self.live_server_url}")
+            expect(page.locator("h1")).to_have_text(f"{self.front_page_heading}")
+            page.get_by_label("Organisation name").fill("test")
+            page.get_by_role("button", name="Search").click()
+            expect(page.locator("h1")).to_have_text("No search results")
+            expect(page.locator("#no-results-info")).to_have_text("There are no results for your criteria.")
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
     def test_invalid_postcode_journey(self):
-        page = self.browser.new_page()
-        page.goto(f"{self.live_server_url}")
-        expect(page.locator("h1")).to_have_text(f"{self.front_page_heading}")
-        page.get_by_label("Postcode").fill("ZZZ1")
-        page.get_by_role("button", name="Search").click()
-        expect(page.locator("h1")).to_have_text(f"{self.front_page_heading}")
-        expect(page.locator("css=.govuk-error-summary")).to_be_visible()
+        try:
+            page = self.browser.new_page()
+            page.goto(f"{self.live_server_url}")
+            expect(page.locator("h1")).to_have_text(f"{self.front_page_heading}")
+            page.get_by_label("Postcode").fill("ZZZ1")
+            page.get_by_role("button", name="Search").click()
+            expect(page.locator("h1")).to_have_text(f"{self.front_page_heading}")
+            expect(page.locator("css=.govuk-error-summary")).to_be_visible()
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e

--- a/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
+++ b/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
@@ -11,11 +11,15 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
         page = self.visit_search_page()
         expect(page.h1).to_have_text(f"{self.front_page_heading}")
 
+        self.test_failed_take_screenshot = False
+
     def test_landing_page_with_url_params(self):
         page = self.visit_search_page_with_url_params("categories=hlpas")
         expect(page.h1).to_have_text(f"{self.front_page_heading}")
         expect(page.error_list).not_to_be_visible()
         expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
+
+        self.test_failed_take_screenshot = False
 
     def test_landing_page_with_multiple_url_params(self):
         page = self.visit_search_page_with_url_params("categories=hlpas&categories=edu")
@@ -29,6 +33,8 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
         expect(page.checkbox_by_label(f"{self.hlpas}")).to_be_checked()
         expect(page.checkbox_by_label(f"{self.edu}")).to_be_checked()
 
+        self.test_failed_take_screenshot = False
+
     def test_postcode_search_journey(self):
         test_cases = [
             "SW1H 9AJ",
@@ -40,6 +46,8 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
                 expect(page.h1).to_have_text("Search results")
                 expect(page.change_search_grey_box.nth(0)).to_have_text(f"Postcode: {postcode}")
                 expect(page.item_from_text("in order of closeness")).to_be_visible()
+
+        self.test_failed_take_screenshot = False
 
     def test_full_search_journey(self):
         page = self.visit_results_page_with_full_search(
@@ -53,6 +61,8 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
             "Legal problem: Housing Loss Prevention Advice Service"
         )
 
+        self.test_failed_take_screenshot = False
+
     def test_invalid_organisation_search(self):
         page = self.browser.new_page()
         page.goto(f"{self.live_server_url}")
@@ -62,6 +72,8 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
         expect(page.locator("h1")).to_have_text("No search results")
         expect(page.locator("#no-results-info")).to_have_text("There are no results for your criteria.")
 
+        self.test_failed_take_screenshot = False
+
     def test_invalid_postcode_journey(self):
         page = self.browser.new_page()
         page.goto(f"{self.live_server_url}")
@@ -70,3 +82,5 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
         page.get_by_role("button", name="Search").click()
         expect(page.locator("h1")).to_have_text(f"{self.front_page_heading}")
         expect(page.locator("css=.govuk-error-summary")).to_be_visible()
+
+        self.test_failed_take_screenshot = False

--- a/fala/apps/adviser/tests/test_translation_playwright.py
+++ b/fala/apps/adviser/tests/test_translation_playwright.py
@@ -5,29 +5,38 @@ from fala.playwright.setup import PlaywrightTestSetup
 class TranslationSelection(PlaywrightTestSetup):
 
     def test_translate_to_welsh(self):
-        page = self.visit_search_page()
-        page.language_dropdown.select_option(label="Welsh")
-        expect(page.h1).to_have_text("Dewch o hyd i gynghorydd cymorth cyfreithiol neu gyfryngwr teuluol")
-        page.search("SA31 3DP")
-        # this tests that the language selection persists to the results page
-        expect(page.h1).to_have_text("Canlyniadau chwilio")
-        page.select_page_number(4).click()
-        # this tests that the language selection persists when pagination buttons are clicked
-        expect(page.h1).to_have_text("Canlyniadau chwilio")
+        try:
+            page = self.visit_search_page()
+            page.language_dropdown.select_option(label="Welsh")
+            expect(page.h1).to_have_text("Dewch o hyd i gynghorydd cymorth cyfreithiol neu gyfryngwr teuluol")
+            page.search("SA31 3DP")
+            # this tests that the language selection persists to the results page
+            expect(page.h1).to_have_text("Canlyniadau chwilio")
+            page.select_page_number(4).click()
+            # this tests that the language selection persists when pagination buttons are clicked
+            expect(page.h1).to_have_text("Canlyniadau chwilio")
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
     def test_translate_to_irish(self):
-        page = self.visit_search_page()
-        # searching for the value of the dropdown, as 'Irish Gaelic' text, is not being found when running test on circleCi
-        page.language_dropdown.select_option(value="ga")
-        expect(page.h1).to_have_text("Aimsigh comhairleoir um chúnamh dlíthiúil nó idirghabhálaí teaghlaigh")
+        try:
+            page = self.visit_search_page()
+            # searching for the value of the dropdown, as 'Irish Gaelic' text, is not being found when running test on circleCi
+            page.language_dropdown.select_option(value="ga")
+            expect(page.h1).to_have_text("Aimsigh comhairleoir um chúnamh dlíthiúil nó idirghabhálaí teaghlaigh")
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e
 
     def test_translate_to_scots(self):
-        page = self.visit_search_page()
-        page.language_dropdown.select_option(label="Scots Gaelic")
-        expect(page.h1).to_have_text("Lorg comhairliche taic laghail no eadar-mheadhanair teaghlaich")
+        try:
+            page = self.visit_search_page()
+            page.language_dropdown.select_option(label="Scots Gaelic")
+            expect(page.h1).to_have_text("Lorg comhairliche taic laghail no eadar-mheadhanair teaghlaich")
 
-        self.test_failed_take_screenshot = False
+        except Exception as e:
+            self.take_screenshot()
+            raise e

--- a/fala/apps/adviser/tests/test_translation_playwright.py
+++ b/fala/apps/adviser/tests/test_translation_playwright.py
@@ -15,13 +15,19 @@ class TranslationSelection(PlaywrightTestSetup):
         # this tests that the language selection persists when pagination buttons are clicked
         expect(page.h1).to_have_text("Canlyniadau chwilio")
 
+        self.test_failed_take_screenshot = False
+
     def test_translate_to_irish(self):
         page = self.visit_search_page()
         # searching for the value of the dropdown, as 'Irish Gaelic' text, is not being found when running test on circleCi
         page.language_dropdown.select_option(value="ga")
         expect(page.h1).to_have_text("Aimsigh comhairleoir um chúnamh dlíthiúil nó idirghabhálaí teaghlaigh")
 
+        self.test_failed_take_screenshot = False
+
     def test_translate_to_scots(self):
         page = self.visit_search_page()
         page.language_dropdown.select_option(label="Scots Gaelic")
         expect(page.h1).to_have_text("Lorg comhairliche taic laghail no eadar-mheadhanair teaghlaich")
+
+        self.test_failed_take_screenshot = False

--- a/fala/playwright/setup.py
+++ b/fala/playwright/setup.py
@@ -2,6 +2,8 @@ import os
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from playwright.sync_api import sync_playwright
 from fala.apps.adviser.tests.page_objects import ResultsPage, OtherRegionPage, SearchPage, CookiesPage
+import pathlib
+import datetime
 
 
 class PlaywrightTestSetup(StaticLiveServerTestCase):
@@ -22,55 +24,79 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
         super().setUp()
         self.browser = self._factory.new_context()
 
+        # Initialise the page object, in order to store the current page object whenever a new page is created
+        self._page = None
+
+        # The rationale behind this approach is when the test reaches the last line, we know that the test passed (e.g. all the self.assert* passed).
+        # At this point, we reset the test_failed member, which was set to True in the setUp.
+        # In tearDown, we now can tell if a test passed or failed and take screenshot when appropriate.
+        # https://stackoverflow.com/questions/27879640/create-screenshot-only-on-test-failure?rq=3
+        self.test_failed_take_screenshot = True
+
     def tearDown(self):
+        if self.test_failed_take_screenshot:
+            self.take_screenshot()
         self.browser.close()
         super().tearDown()
+
+    def take_screenshot(self):
+        # make a directory to store screenshot locally
+        screenshot_dir = pathlib.Path("fala/playwright/screenshots")
+        screenshot_dir.mkdir(exist_ok=True)
+
+        # name screenshots appropriately with date & time
+        test_name = self._testMethodName
+        timestamp = datetime.datetime.now().strftime("%d-%-m-%Y %H:%M:%S")
+        screenshot_path = screenshot_dir / f"{test_name}_{timestamp}.png"
+
+        # call playwright `screenshot` method, and take full page screenshot
+        self._page.screenshot(path=str(screenshot_path), full_page=True)
 
     def visit_results_page(self, postcode, checkbox_labels=None):
         if checkbox_labels is None:
             checkbox_labels = []
-        page = self.browser.new_page()
-        page.goto(f"{self.live_server_url}")
-        page.get_by_label("Postcode").fill(postcode)
+        self._page = self.browser.new_page()
+        self._page.goto(f"{self.live_server_url}")
+        self._page.get_by_label("Postcode").fill(postcode)
         for label in checkbox_labels:
-            page.get_by_label(label).check()
-        page.get_by_role("button", name="Search").click()
-        if page.locator("#changeSearchButton"):
-            return ResultsPage(page)
+            self._page.get_by_label(label).check()
+        self._page.get_by_role("button", name="Search").click()
+        if self._page.locator("#changeSearchButton"):
+            return ResultsPage(self._page)
         else:
-            return OtherRegionPage(page)
+            return OtherRegionPage(self._page)
 
     def visit_results_page_with_full_search(self, postcode, organisation, checkbox_labels):
-        page = self.browser.new_page()
-        page.goto(f"{self.live_server_url}")
-        page.get_by_label("Postcode").fill(postcode)
-        page.get_by_label("Organisation name").fill(organisation)
+        self._page = self.browser.new_page()
+        self._page.goto(f"{self.live_server_url}")
+        self._page.get_by_label("Postcode").fill(postcode)
+        self._page.get_by_label("Organisation name").fill(organisation)
         for label in checkbox_labels:
-            page.get_by_label(label).check()
-        page.get_by_role("button", name="Search").click()
-        if page.locator("#changeSearchButton"):
-            return ResultsPage(page)
+            self._page.get_by_label(label).check()
+        self._page.get_by_role("button", name="Search").click()
+        if self._page.locator("#changeSearchButton"):
+            return ResultsPage(self._page)
         else:
-            return OtherRegionPage(page)
+            return OtherRegionPage(self._page)
 
     def visit_search_page_with_url_params(self, url_params):
-        page = self.browser.new_page()
-        page.goto(f"{self.live_server_url}/?{url_params}")
-        return SearchPage(page)
+        self._page = self.browser.new_page()
+        self._page.goto(f"{self.live_server_url}/?{url_params}")
+        return SearchPage(self._page)
 
     def visit_search_page(self):
-        page = self.browser.new_page()
-        page.goto(f"{self.live_server_url}")
-        return SearchPage(page)
+        self._page = self.browser.new_page()
+        self._page.goto(f"{self.live_server_url}")
+        return SearchPage(self._page)
 
     def visit_cookies_page_from_footer(self):
-        page = self.browser.new_page()
-        page.goto(f"{self.live_server_url}")
-        page.locator("#cookies_footer_link").click()
-        return CookiesPage(page)
+        self._page = self.browser.new_page()
+        self._page.goto(f"{self.live_server_url}")
+        self._page.locator("#cookies_footer_link").click()
+        return CookiesPage(self._page)
 
     def visit_cookies_page_from_banner(self):
-        page = self.browser.new_page()
-        page.goto(f"{self.live_server_url}")
-        page.locator("#cookies_banner_view_link").click()
-        return CookiesPage(page)
+        self._page = self.browser.new_page()
+        self._page.goto(f"{self.live_server_url}")
+        self._page.locator("#cookies_banner_view_link").click()
+        return CookiesPage(self._page)

--- a/fala/playwright/setup.py
+++ b/fala/playwright/setup.py
@@ -27,15 +27,7 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
         # Initialise the page object, in order to store the current page object whenever a new page is created
         self._page = None
 
-        # The rationale behind this approach is when the test reaches the last line, we know that the test passed (e.g. all the self.assert* passed).
-        # At this point, we reset the test_failed member, which was set to True in the setUp.
-        # In tearDown, we now can tell if a test passed or failed and take screenshot when appropriate.
-        # https://stackoverflow.com/questions/27879640/create-screenshot-only-on-test-failure?rq=3
-        self.test_failed_take_screenshot = True
-
     def tearDown(self):
-        if self.test_failed_take_screenshot:
-            self.take_screenshot()
         self.browser.close()
         super().tearDown()
 


### PR DESCRIPTION
## What does this pull request do?

- have a way to take screenshots for the playwright tests only
- amend typos
- initialise the page object
- use `self._page` for all the methods in this class, so they have the initialised page object
- update the set-up for FALA cookies specific tests
- circleci update

## Any other changes that would benefit highlighting?

- n/a

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
