### PR TITLE
EL-1909 single cat search page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ fala/static
 
 # VSCode
 .vscode
+fala/apps/adviser/fala.code-workspace

--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -8,7 +8,6 @@ import laalaa.api as laalaa
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-import logging
 
 
 from .regions import Region
@@ -37,7 +36,7 @@ class CapitalisedPostcodeField(forms.CharField):
         # Capitalise the input value
         capitalised_value = value.upper() if value else value
         return super().to_python(capitalised_value)
-logger = logging.getLogger(__name__)
+
 
 # This is so that we can hit the front page with query parameters in url and not see form validation errors
 # In django, form validation happens when the data is cleaned, i.e. form validation, form errors, form cleaned
@@ -221,8 +220,6 @@ class SingleCategorySearchForm(forms.Form):
         postcode = cleaned_data.get("postcode")
         categories = self.data.get("category")
 
-        logger.debug("343434Validating postcode and categories: %s, %s", postcode, categories)
-
         # Validate postcode and set `_country_from_valid_postcode`
         if postcode:
             valid_postcode = self.validate_postcode_and_return_country(postcode)
@@ -230,7 +227,6 @@ class SingleCategorySearchForm(forms.Form):
                 self.add_error("postcode", _("Enter a valid postcode"))
             else:
                 self._country_from_valid_postcode = valid_postcode  # This is used by the `region` property
-                logger.debug("67676767Valid postcode: %s", valid_postcode)
 
         # Check if categories are provided
         if not categories:
@@ -240,54 +236,18 @@ class SingleCategorySearchForm(forms.Form):
 
         return cleaned_data
 
-
-    # this is required if i want to rename category to categories in the single_category_search.html file
-    # however this then breaks the search as it just reloads the page
-
-    # def search(self):
-    #     if self.is_valid():
-    #         try:
-    #             postcode = self.cleaned_data.get("postcode")
-    #             if not postcode:
-    #                 self.add_error("postcode", _("Enter a valid postcode"))
-    #                 return {}
-
-    #             # Use `self.categories` for the search (ensure it is passed as a list)
-    #             data = laalaa.find(
-    #                 postcode=postcode,
-    #                 categories=self.categories,  # Pass the list of categories
-    #                 page=1,  # Always default to the first page for simplicity
-    #             )
-
-    #             if "error" in data:
-    #                 self.add_error("postcode", data["error"])
-    #                 return {}
-    #             return data
-
-    #         except laalaa.LaaLaaError:
-    #             self.add_error("postcode", _("Error looking up legal advisers. Please try again later."))
-    #             return {}
-
-    #     return {}
-
     @property
     def region(self):
-        # Log the start of the method
-        logger.debug("Entering `region` property.")
         # retrieve the api call variables
         country_from_valid_postcode = getattr(self, "_country_from_valid_postcode", None)
-        logger.debug("Country from valid postcode: %s", country_from_valid_postcode)
 
         # Return `Region.ENGLAND_OR_WALES` from `clean` if set
         if not country_from_valid_postcode:
             region = getattr(self, "_region", None)
-            logger.debug("111111NOT Country from valid postcode: %s", country_from_valid_postcode)
-            logger.debug("Region from `_region` attribute: %s", region)
             return region
 
         # for Guernsey & Jersey the country comes back as 'Channel Islands', we are using `nhs_ha` key to distinguish between them
         country, nhs_ha = country_from_valid_postcode
-        logger.debug("fefvasefvbsefCountry: %s, NHS HA: %s", country, nhs_ha)
 
         if country == "Northern Ireland":
             return Region.NI
@@ -302,21 +262,17 @@ class SingleCategorySearchForm(forms.Form):
         elif country in ["England", "Wales"]:
             return Region.ENGLAND_OR_WALES
         else:
-            logger.error("Invalid region: country=%s, nhs_ha=%s", country, nhs_ha)
             self.add_error("postcode", _("This service is only available for England and Wales"))
             return None
 
     @property
     def current_page(self):
         page = self.cleaned_data.get("page", 1)
-        logger.debug("Current page: %s", page)
         return page
 
     def validate_postcode_and_return_country(self, postcode):
-        logger.debug("Validating postcode: %s", postcode)
         try:
             if not isinstance(postcode, str) or not postcode.strip():
-                logger.warning("Invalid postcode input: %s", postcode)
                 return False
 
             session = requests.Session()
@@ -325,18 +281,14 @@ class SingleCategorySearchForm(forms.Form):
             session.mount("https://", adapter)
 
             url = settings.POSTCODE_IO_URL + f"{postcode}"
-            logger.debug("Requesting postcode data from URL: %s", url)
             response = session.get(url, timeout=5)
 
             if response.status_code != 200:
-                logger.error("Failed to retrieve postcode data. Status code: %s", response.status_code)
                 return False
 
             data = response.json()
-            logger.debug("Postcode API response: %s", data)
 
             if not data.get("result"):
-                logger.warning("No results found for postcode: %s", postcode)
                 return False
 
             first_result_in_list = data["result"][0]
@@ -344,45 +296,35 @@ class SingleCategorySearchForm(forms.Form):
             nhs_ha = first_result_in_list.get("nhs_ha")
 
             if country and nhs_ha:
-                logger.info("Postcode validated. Country: %s, NHS HA: %s", country, nhs_ha)
                 return country, nhs_ha
             else:
-                logger.warning("Country or NHS HA missing in response.")
                 return False
 
         except requests.RequestException as e:
-            logger.error("RequestException during postcode validation: %s", e)
             self.add_error("postcode", _("Error looking up legal advisers. Please try again later."))
             return False
 
     def search(self):
-        logger.debug("Initiating search.")
         if self.is_valid():
             try:
                 postcode = self.cleaned_data.get("postcode")
                 categories = self.categories
-                logger.debug("Starting laalaa search with postcode: %s and categories: %s", postcode, categories)
 
                 # Call the API
                 data = laalaa.find(postcode=postcode, categories=categories, page=1)
 
                 # Check for errors in the response
                 if "error" in data:
-                    logger.error("Error from laalaa search: %s", data["error"])
                     self.add_error("postcode", data["error"])
                     return []
 
                 # Extract only the 'results' key
+                # this may be where the problem is with the display of the results
+                # i remove everythng but the results but I think the template wants a
+                # block called 'data' within which exists `results`` so data.results cntains the search results
                 results = data.get("results", [])
-                logger.info("Search completed successfully. Extracted results: %s", results)
                 return results
             except laalaa.LaaLaaError as e:
-                logger.error("LaaLaaError during search: %s", e)
                 self.add_error("postcode", _("Error looking up legal advisers. Please try again later."))
                 return []
-
-        logger.warning("Search form is invalid.")
         return []
-
-
-

--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -287,7 +287,7 @@ class SingleCategorySearchForm(forms.Form):
 
         # for Guernsey & Jersey the country comes back as 'Channel Islands', we are using `nhs_ha` key to distinguish between them
         country, nhs_ha = country_from_valid_postcode
-        logger.debug("Country: %s, NHS HA: %s", country, nhs_ha)
+        logger.debug("fefvasefvbsefCountry: %s, NHS HA: %s", country, nhs_ha)
 
         if country == "Northern Ireland":
             return Region.NI

--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -300,7 +300,7 @@ class SingleCategorySearchForm(forms.Form):
             else:
                 return False
 
-        except requests.RequestException as e:
+        except requests.RequestException:
             self.add_error("postcode", _("Error looking up legal advisers. Please try again later."))
             return False
 
@@ -324,7 +324,7 @@ class SingleCategorySearchForm(forms.Form):
                 # block called 'data' within which exists `results`` so data.results cntains the search results
                 results = data.get("results", [])
                 return results
-            except laalaa.LaaLaaError as e:
+            except laalaa.LaaLaaError:
                 self.add_error("postcode", _("Error looking up legal advisers. Please try again later."))
                 return []
         return []

--- a/fala/apps/adviser/models.py
+++ b/fala/apps/adviser/models.py
@@ -16,7 +16,10 @@ class SatisfactionFeedback(models.Model):
     def __str__(self):
         return f"Feedback {self.id}"
 
+
 logger = logging.getLogger(__name__)
+
+
 class EnglandOrWalesState(object):
     def __init__(self, form):
         self._form = form

--- a/fala/apps/adviser/models.py
+++ b/fala/apps/adviser/models.py
@@ -1,5 +1,9 @@
 from django.db import models
 from django.utils import timezone
+from .regions import Region
+from .laa_laa_paginator import LaaLaaPaginator
+import urllib
+from django.conf import settings
 
 
 class SatisfactionFeedback(models.Model):
@@ -10,3 +14,145 @@ class SatisfactionFeedback(models.Model):
 
     def __str__(self):
         return f"Feedback {self.id}"
+
+
+class EnglandOrWalesState(object):
+    def __init__(self, form):
+        self._form = form
+        self._data = form.search()
+
+    @property
+    def template_name(self):
+        return "results.html"
+
+    def get_queryset(self):
+        return self._data.get("results", None)
+
+    def get_context_data(self):
+        pages = LaaLaaPaginator(self._data["count"], 10, 3, self._form.current_page)
+        current_page = pages.current_page()
+        params = {
+            "postcode": self._form.cleaned_data["postcode"],
+            "name": self._form.cleaned_data["name"],
+        }
+        categories = self._form.cleaned_data["categories"]
+
+        # create list of tuples which can be passed to urlencode for pagination links
+        category_tuples = [("categories", c) for c in categories]
+
+        def item_for(page_num):
+            if len(categories) > 0:
+                page_params = {"page": page_num}
+                href = (
+                    "/search?"
+                    + urllib.parse.urlencode({**page_params, **params})
+                    + "&"
+                    + urllib.parse.urlencode(category_tuples)
+                )
+            else:
+                page_params = {"page": page_num}
+                href = "/search?" + urllib.parse.urlencode({**page_params, **params})
+
+            return {"number": page_num, "current": self._form.current_page == page_num, "href": href}
+
+        pagination = {"items": [item_for(page_num) for page_num in pages.page_range]}
+
+        if current_page.has_previous():
+            if len(categories) > 0:
+                page_params = {"page": current_page.previous_page_number()}
+                prev_link = (
+                    "/search?"
+                    + urllib.parse.urlencode({**page_params, **params})
+                    + "&"
+                    + urllib.parse.urlencode(category_tuples)
+                )
+            else:
+                page_params = {"page": current_page.previous_page_number()}
+                prev_link = "/search?" + urllib.parse.urlencode({**page_params, **params})
+            pagination["previous"] = {"href": prev_link}
+
+        if current_page.has_next():
+            if len(categories) > 0:
+                page_params = {"page": current_page.next_page_number()}
+                href = (
+                    "/search?"
+                    + urllib.parse.urlencode({**page_params, **params})
+                    + "&"
+                    + urllib.parse.urlencode(category_tuples)
+                )
+            else:
+                page_params = {"page": current_page.next_page_number()}
+                href = "/search?" + urllib.parse.urlencode({**page_params, **params})
+            pagination["next"] = {"href": href}
+
+        return {
+            "form": self._form,
+            "data": self._data,
+            "params": params,
+            "FEATURE_FLAG_SURVEY_MONKEY": settings.FEATURE_FLAG_SURVEY_MONKEY,
+            "pagination": pagination,
+        }
+
+
+class OtherJurisdictionState(object):
+    REGION_TO_LINK = {
+        Region.NI: {
+            "link": "https://www.nidirect.gov.uk/articles/legal-aid-schemes",
+            "region": "Northern Ireland",
+        },
+        Region.IOM: {
+            "link": "https://www.gov.im/categories/benefits-and-financial-support/legal-aid/",
+            "region": "the Isle of Man",
+        },
+        Region.JERSEY: {
+            "link": "https://www.legalaid.je/",
+            "region": "Jersey",
+        },
+        Region.GUERNSEY: {
+            "link": "https://www.gov.gg/legalaid",
+            "region": "Guernsey",
+        },
+    }
+
+    def __init__(self, region, postcode):
+        self._region = region
+        self._postcode = postcode
+
+    def get_queryset(self):
+        return []
+
+    @property
+    def template_name(self):
+        return "other_region.html"
+
+    def get_context_data(self):
+        region_data = self.REGION_TO_LINK[self._region]
+        return {
+            "postcode": self._postcode,
+            "link": region_data["link"],
+            "region": region_data["region"],
+        }
+
+
+class ErrorState(object):
+    def __init__(self, form):
+        self._form = form
+
+    @property
+    def template_name(self):
+        return "search.html"
+
+    def get_queryset(self):
+        return []
+
+    def get_context_data(self):
+        errorList = []
+        for field, error in self._form.errors.items():
+            # choose the first field is the error in form-wide
+            if field == "__all__":
+                item = {"text": error[0], "href": "#id_postcode"}
+            else:
+                item = {"text": error[0], "href": f"#id_{field}"}
+            errorList.append(item)
+
+        return {"form": self._form, "data": {}, "errorList": errorList}

--- a/fala/apps/adviser/utils.py
+++ b/fala/apps/adviser/utils.py
@@ -1,0 +1,25 @@
+# utils.py
+
+CATEGORY_TRANSLATIONS = {
+    "aap": "claims-against-public-authorities",
+    "med": "clinical-negligence",
+    "com": "community-care",
+    "crm": "crime",
+    "deb": "debt",
+    "disc": "discrimination",
+    "edu": "education",
+    "mat": "family",
+    "fmed": "family-mediation",
+    "hou": "housing",
+    "hlpas": "hlpas",
+    "immas": "immigration-asylum",
+    "mhe": "mental-health",
+    "mosl": "modern-slavery",
+    "pl": "prison-law",
+    "pub": "public-law",
+    "wb": "welfare-benefits",
+}
+
+
+def get_category_display_name(category_code):
+    return CATEGORY_TRANSLATIONS.get(category_code)

--- a/fala/apps/adviser/utils.py
+++ b/fala/apps/adviser/utils.py
@@ -20,6 +20,27 @@ CATEGORY_TRANSLATIONS = {
     "wb": "welfare-benefits",
 }
 
+SLUG_TO_CODE = {v: k for k, v in CATEGORY_TRANSLATIONS.items()}
+
+
+def get_category_code_from_slug(slug):
+    return SLUG_TO_CODE.get(slug)
+
 
 def get_category_display_name(category_code):
     return CATEGORY_TRANSLATIONS.get(category_code)
+
+
+CATEGORY_MESSAGES = {
+    "hlpas": "Tell the adviser your home is at risk and you want advice through the Housing Loss Prevention Advice Service.",
+    "welfare-benefits": (
+        "Legal aid for advice about welfare benefits is only available if you are appealing a decision made by the social security tribunal. "
+        "This appeal must be in the Upper Tribunal, Court of Appeal or Supreme Court.\n\n"
+        "For any other benefits issue, ask the legal adviser if you can get free legal advice or if you will have to pay for it."
+    ),
+    "clinical-negligence": "Legal aid for advice about clinical negligence is usually only available if you have a child that suffered a brain injury during pregnancy, birth or the first 8 weeks of life.",
+}
+
+CATEGORY_DISPLAY_NAMES = {
+    "hlpas": "Housing Loss Prevention Advice Service",
+}

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -97,7 +97,7 @@ class SingleCategorySearchView(TemplateView):
 
         # Let the state handle the logic for results
         results = state.get_queryset()
-        template_name = state.template_name
+        # template_name = state.template_name
 
         search_url = reverse("single_category_search", kwargs={"category": category_slug})
 

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -11,6 +11,8 @@ from django.views import View
 from .forms import AdviserSearchForm, AdviserRootForm
 from .laa_laa_paginator import LaaLaaPaginator
 from .regions import Region
+from django.shortcuts import redirect
+from .utils import get_category_display_name
 
 
 class RobotsTxtView(View):
@@ -50,8 +52,39 @@ class CommonContextMixin:
             }
         )
         return context
+from django.shortcuts import redirect
+from .utils import get_category_display_name
 
+class SingleCategorySearchView(CommonContextMixin, TemplateView):
+    template_name = "adviser/single_category_search.html"
 
+    def get(self, request, *args, **kwargs):
+        category_code = request.GET.get("categories")
+        if category_code:
+            category_slug = get_category_display_name(category_code)
+            if category_slug:
+                return redirect('single_category_search', category=category_slug)
+            else:
+                return redirect('search')
+
+        category_slug = kwargs.get("category")
+        if not category_slug:
+            return redirect('search')
+
+        context = self.get_context_data(**kwargs)
+        form = AdviserRootForm(data=request.GET or None)
+
+        context.update(
+            {
+                "form": form,
+                "category_slug": category_slug,
+                "category_display_name": category_slug.replace("-", " ").title(),
+                "current_url": request.path,
+                "CHECK_LEGAL_AID_URL": settings.CHECK_LEGAL_AID_URL,
+            }
+        )
+
+        return self.render_to_response(context)
 class AdviserView(CommonContextMixin, TemplateView):
     template_name = "adviser/search.html"
 

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -13,6 +13,7 @@ from .forms import SingleCategorySearchForm
 from .utils import CATEGORY_MESSAGES, CATEGORY_DISPLAY_NAMES, get_category_display_name, get_category_code_from_slug
 import logging
 
+
 class RobotsTxtView(View):
     def get(self, request):
         environment = os.getenv("ENVIRONMENT", "development").lower()
@@ -51,7 +52,10 @@ class CommonContextMixin:
         )
         return context
 
+
 logger = logging.getLogger(__name__)
+
+
 class SingleCategorySearchView(TemplateView):
     template_name = "adviser/single_category_search.html"
 
@@ -108,8 +112,10 @@ class SingleCategorySearchView(TemplateView):
             "search_url": search_url,
         }
 
-        return render(request, template_name, context)
-
+        return render(request, self.template_name, context)
+        # so to show the search page this must be self.template_name
+        # but when i want to show results it needs to be template_name
+        # so that it can take it from EnglandOrWalesState which uses results.html
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/fala/apps/laalaa/api.py
+++ b/fala/apps/laalaa/api.py
@@ -2,6 +2,7 @@
 from urllib.parse import urlencode
 from collections import OrderedDict
 import requests
+import logging
 
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
@@ -13,7 +14,7 @@ try:
 except NameError:
     basestring = str
 
-
+logger = logging.getLogger(__name__)
 def get_categories():
     if settings.LAALAA_API_HOST:
         categories = LaalaaProviderCategoriesApiClient.singleton(settings.LAALAA_API_HOST, _).get_categories()
@@ -66,5 +67,6 @@ def find(postcode=None, categories=None, page=1, organisation_types=None, organi
     )
 
     data["results"] = list(map(decode_categories, data.get("results", [])))
+    logger.debug(f"find: processed results type={type(data['results'])}, processed results={data['results'][:3]}")  # Log first 3 processed results
 
     return data

--- a/fala/apps/laalaa/api.py
+++ b/fala/apps/laalaa/api.py
@@ -15,6 +15,8 @@ except NameError:
     basestring = str
 
 logger = logging.getLogger(__name__)
+
+
 def get_categories():
     if settings.LAALAA_API_HOST:
         categories = LaalaaProviderCategoriesApiClient.singleton(settings.LAALAA_API_HOST, _).get_categories()
@@ -67,6 +69,8 @@ def find(postcode=None, categories=None, page=1, organisation_types=None, organi
     )
 
     data["results"] = list(map(decode_categories, data.get("results", [])))
-    logger.debug(f"find: processed results type={type(data['results'])}, processed results={data['results'][:3]}")  # Log first 3 processed results
+    logger.debug(
+        f"find: processed results type={type(data['results'])}, processed results={data['results'][:3]}"
+    )  # Log first 3 processed results
 
     return data

--- a/fala/templates/adviser/single_category_search.html
+++ b/fala/templates/adviser/single_category_search.html
@@ -1,0 +1,93 @@
+{% extends 'adviser/adviser_base.html' %}
+
+{% block pageTitle %}Find a Legal Aid Adviser or Family Mediator{% endblock %}
+
+{% import "macros/element.html" as Element %}
+{% import "macros/forms.html" as Form %}
+
+{%- from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary %}
+{%- from 'govuk_frontend_jinja/components/checkboxes/macro.html' import govukCheckboxes %}
+{%- from "govuk_frontend_jinja/components/input/macro.html" import govukInput %}
+
+{% block content %}
+  <div class="govuk-grid-column-two-thirds">
+      <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+      {% if form.errors %}
+        {{ govukErrorSummary({
+          "titleText": "There is a problem",
+          "errorList": errorList
+        }) }}
+      {% endif %}
+      <h1 class="govuk-heading-xl"> Find a legal aid adviser or family mediator </h1>
+      <p class="govuk-body">You need to provide information about your finances to find out if you qualify for legal aid.</p>
+      <p class="govuk-body"><a class="govuk-link" href="{{ CHECK_LEGAL_AID_URL }}" target="_blank" rel="noopener">Check if you qualify for legal aid (opens in a new tab)</a></p>
+  </div>
+
+  {% block search_form %}
+      <div class="govuk-grid-column-full">
+        <div class="laa-fala__grey-box">
+
+          <form action="search" id="fala_questions">
+            {% set errorMessage = {'err': ""} %}
+
+            {% if form.errors %}
+              {% call Element.errorText() %}
+                {% for k, error in form.errors.items() %}
+                  {% if errorMessage.update({'err': error | striptags}) %}{% endif %}
+                {% endfor %}
+              {% endcall %}
+            {% endif %}
+
+            {% if 'postcode' in form.errors or form.errors['__all__'] %}
+              {{ govukInput({
+                'label': {
+                  'text': "Postcode",
+                  'classes': 'govuk-label--s',
+                },
+                'value': form.postcode.value(),
+                'errorMessage': { 'text': form.errors['postcode'][0] },
+                'hint': {
+                  'text' : "For example, NE31 1SF",
+                },
+                'attributes': {
+                   'maxLength': 30,
+                },
+                'id': 'id_postcode',
+                'classes': 'govuk-input--width-10',
+                'name': "postcode"
+              }) }}
+            {% else %}
+              {{ govukInput({
+                'label': {
+                  'text': "Postcode",
+                  'classes': 'govuk-label--s',
+                },
+                'value': form.postcode.value(),
+                'hint': {
+                  'text' : "For example, NE31 1SF",
+                },
+                'attributes': {
+                   'maxLength': 30,
+                },
+                'id': 'id_postcode',
+                'classes': 'govuk-input--width-10',
+                'name': "postcode"
+              }) }}
+            {% endif %}
+
+            {{ govukButton({
+              'text': "Search",
+              'type': "submit",
+              'classes': "govuk-!-margin-bottom-2",
+              'id': "searchButton",
+              'name': "search"
+            }) }}
+          </form>
+        </div>
+      </div>
+  {% endblock %}
+
+    <div class="govuk-grid-column-full">
+      <p class="govuk-body govuk-!-margin-top-5">If you are a provider and your details are incorrect, please contact your contract manager.</p>
+    </div>
+{% endblock %}

--- a/fala/templates/adviser/single_category_search.html
+++ b/fala/templates/adviser/single_category_search.html
@@ -34,7 +34,12 @@
   {% block search_form %}
       <div class="govuk-grid-column-two-thirds">
 
-        <form action="search" id="fala_questions">
+          <form action="{{ search_url }}" method="get" id="fala_questions">
+            <input type="hidden" name="category" value="{{ category_code }}">
+
+            <p>DEBUG: Category slug: {{ category_slug }}</p>
+            <p>DEBUG: Category code: {{ category_code }}</p>
+
           {% set errorMessage = {'err': ""} %}
 
           {% if form.errors %}

--- a/fala/templates/adviser/single_category_search.html
+++ b/fala/templates/adviser/single_category_search.html
@@ -18,76 +18,104 @@
           "errorList": errorList
         }) }}
       {% endif %}
-      <h1 class="govuk-heading-xl"> Find a legal aid adviser or family mediator </h1>
-      <p class="govuk-body">You need to provide information about your finances to find out if you qualify for legal aid.</p>
-      <p class="govuk-body"><a class="govuk-link" href="{{ CHECK_LEGAL_AID_URL }}" target="_blank" rel="noopener">Check if you qualify for legal aid (opens in a new tab)</a></p>
+      <h1 class="govuk-heading-xl"> Find a legal aid adviser for 
+        {% if category_slug == 'hlpas' %}
+          {{ category_display_name }}
+        {% else %}
+          {{ category_display_name | lower }}
+        {% endif %}
+      </h1>
+      <p class="govuk-body">Search for official legal aid advisers in England and Wales.</p>
+      {% if category_message %}
+        <p class="govuk-body">{{ category_message |linebreaks }}</p>
+      {% endif %}
   </div>
 
   {% block search_form %}
-      <div class="govuk-grid-column-full">
-        <div class="laa-fala__grey-box">
+      <div class="govuk-grid-column-two-thirds">
 
-          <form action="search" id="fala_questions">
-            {% set errorMessage = {'err': ""} %}
+        <form action="search" id="fala_questions">
+          {% set errorMessage = {'err': ""} %}
 
-            {% if form.errors %}
-              {% call Element.errorText() %}
-                {% for k, error in form.errors.items() %}
-                  {% if errorMessage.update({'err': error | striptags}) %}{% endif %}
-                {% endfor %}
-              {% endcall %}
-            {% endif %}
+          {% if form.errors %}
+            {% call Element.errorText() %}
+              {% for k, error in form.errors.items() %}
+                {% if errorMessage.update({'err': error | striptags}) %}{% endif %}
+              {% endfor %}
+            {% endcall %}
+          {% endif %}
 
-            {% if 'postcode' in form.errors or form.errors['__all__'] %}
-              {{ govukInput({
-                'label': {
-                  'text': "Postcode",
-                  'classes': 'govuk-label--s',
-                },
-                'value': form.postcode.value(),
-                'errorMessage': { 'text': form.errors['postcode'][0] },
-                'hint': {
-                  'text' : "For example, NE31 1SF",
-                },
-                'attributes': {
-                   'maxLength': 30,
-                },
-                'id': 'id_postcode',
-                'classes': 'govuk-input--width-10',
-                'name': "postcode"
-              }) }}
-            {% else %}
-              {{ govukInput({
-                'label': {
-                  'text': "Postcode",
-                  'classes': 'govuk-label--s',
-                },
-                'value': form.postcode.value(),
-                'hint': {
-                  'text' : "For example, NE31 1SF",
-                },
-                'attributes': {
-                   'maxLength': 30,
-                },
-                'id': 'id_postcode',
-                'classes': 'govuk-input--width-10',
-                'name': "postcode"
-              }) }}
-            {% endif %}
+          <p class="govuk-body govuk-!-font-weight-bold">Next steps</p>
+          <ol class="govuk-list govuk-list--number">
+            <li>We'll show you a list of legal advisers.</li>
+            <li>When you contact the adviser they'll ask about your problem and finances to work out if you can get legal aid.</li>
+          </ol>
 
-            {{ govukButton({
-              'text': "Search",
-              'type': "submit",
-              'classes': "govuk-!-margin-bottom-2",
-              'id': "searchButton",
-              'name': "search"
+          {% if 'postcode' in form.errors or form.errors['__all__'] %}
+            {{ govukInput({
+              'label': {
+                'text': "What is your postcode?",
+                'classes': 'govuk-label--s',
+              },
+              'value': form.postcode.value(),
+              'errorMessage': { 'text': form.errors['postcode'][0] },
+              'hint': {
+                'text' : "For example, SW1H 9AJ",
+              },
+              'attributes': {
+                  'maxLength': 30,
+              },
+              'id': 'id_postcode',
+              'classes': 'govuk-input--width-10',
+              'name': "postcode"
             }) }}
-          </form>
-        </div>
+          {% else %}
+            {{ govukInput({
+              'label': {
+                'text': "What is your postcode?",
+                'classes': 'govuk-label--s',
+              },
+              'value': form.postcode.value(),
+              'hint': {
+                'text' : "For example, SW1H 9AJ",
+              },
+              'attributes': {
+                  'maxLength': 30,
+              },
+              'id': 'id_postcode',
+              'classes': 'govuk-input--width-10',
+              'name': "postcode"
+            }) }}
+          {% endif %}
+
+          {{ govukButton({
+            'text': "Search",
+            'type': "submit",
+            'classes': "govuk-!-margin-bottom-2",
+            'id': "searchButton",
+            'name': "search"
+          }) }}
+        </form>
       </div>
   {% endblock %}
 
-    <div class="govuk-grid-column-full">
-      <p class="govuk-body govuk-!-margin-top-5">If you are a provider and your details are incorrect, please contact your contract manager.</p>
-    </div>
+  {% if results %}
+  <h2 class="govuk-heading-l">Results</h2>
+  <ul class="govuk-list govuk-list--bullet">
+    {% for item in results %}
+      <li>
+        <h3>{{ item.organisation.name }}</h3>
+        <p>{{ item.location.address }}, {{ item.location.city }}, {{ item.location.postcode }}</p>
+        <p>Phone: {{ item.telephone }}</p>
+        {% if item.distance %}
+          <p>{{ item.distance|round(1) }} miles away</p>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <p>No results found for the given postcode and category.</p>
+{% endif %}
+
+
 {% endblock %}

--- a/fala/urls.py
+++ b/fala/urls.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from django.conf import settings
 from django.urls import re_path
+
 from adviser.views import (
     AccessibilityView,
     AdviserView,

--- a/fala/urls.py
+++ b/fala/urls.py
@@ -1,5 +1,4 @@
-# coding=utf-8
-from django.conf import settings
+# urls.py
 
 from django.urls import re_path
 from adviser.views import (
@@ -10,6 +9,7 @@ from adviser.views import (
     CookiesView,
     RobotsTxtView,
     SecurityTxtView,
+    SingleCategorySearchView,
 )
 from django.views.static import serve
 
@@ -21,4 +21,6 @@ urlpatterns = [
     re_path(r"^search$", SearchView.as_view(), name="search"),
     re_path(r"^robots\.txt$", RobotsTxtView.as_view(), name="robots_txt"),
     re_path(r"^security\.txt$", SecurityTxtView.as_view(), name="security_txt"),
+    re_path(r"^single-category-search/(?P<category>[\w-]+)$", SingleCategorySearchView.as_view(), name="single_category_search"),
+    re_path(r"^single-category-search$", SingleCategorySearchView.as_view(), name="single_category_search_query"),
 ] + [re_path(r"^static/(?P<path>.*)$", serve, {"document_root": settings.STATIC_ROOT})]

--- a/fala/urls.py
+++ b/fala/urls.py
@@ -1,5 +1,5 @@
-# urls.py
-
+# coding=utf-8
+from django.conf import settings
 from django.urls import re_path
 from adviser.views import (
     AccessibilityView,
@@ -21,6 +21,10 @@ urlpatterns = [
     re_path(r"^search$", SearchView.as_view(), name="search"),
     re_path(r"^robots\.txt$", RobotsTxtView.as_view(), name="robots_txt"),
     re_path(r"^security\.txt$", SecurityTxtView.as_view(), name="security_txt"),
-    re_path(r"^single-category-search/(?P<category>[\w-]+)$", SingleCategorySearchView.as_view(), name="single_category_search"),
+    re_path(
+        r"^single-category-search/(?P<category>[\w-]+)$",
+        SingleCategorySearchView.as_view(),
+        name="single_category_search",
+    ),
     re_path(r"^single-category-search$", SingleCategorySearchView.as_view(), name="single_category_search_query"),
 ] + [re_path(r"^static/(?P<path>.*)$", serve, {"document_root": settings.STATIC_ROOT})]


### PR DESCRIPTION
## What does this pull request do?

add new single category search page
add tests
add custom content
add custom styling for hlpas

you can test localy with this url:
http://localhost:8000/single-category-search?categories=med&search=

http://localhost:8000/single-category-search?categories=wb&search=
or modify it for the UAT environment.
You can swap the category code for any other one and it will work e.g wb, pl, hou, mat, com etc 

Next steps:
at present you can submit a postcode which queries LAALAA with the postcode and category and returns a result set. which looks like this:
results=[{'telephone': '01625 704 090', 'location': {'address': 'Riverside Court', 'city': 'Wilmslow', 'postcode': 'SK9 1DL', 'point': {'type': 'Point', 'coordinates': [-2.226143, 53.329065]}, 'type': 'Office'}, 'organisation':.....
However when it gets to the template to display it it looks like this:
"Search results: {'count': 146, 'next': 'https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/legal-advisers/?categories=med&page=2&postcode=WA157UE', 'previous': None, 'results': [{'telephone': '01625 704 090', 'location': {'address': 'Riverside Court', 'city': 'Wilmslow', 'postcode': 'SK9 1D

the extra text at the beginning is breaking the display. so somewhere between getting the LAALAA response and displaying it we are offloading some processing to EnglandOrWalesState and thats where I am stuck.

This issue above is solved, but in solving it I kicked the problem down the road. as a result of transforming the data myself it now cannot be displayed on the results.html template
see the comments added in this commit:
https://github.com/ministryofjustice/fala/pull/380/commits/da1a68010c1c13f70bb0a33ffb69b303ab9e0ddf

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
