### PR TITLE
EL-1921: Add organisation name as a hidden text of the 'View on map' link

### DIFF
--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -109,6 +109,7 @@
                 <span class="notranslate" translate="no">{{ item.location.postcode }}</span>
             </div>
             <a class="govuk-link govuk-!-display-none-print" class="url" target="_blank" rel="noopener" href="https://www.google.com/maps/search/?{{ item|google_map_params|urlencode }}">
+              <p class="govuk-visually-hidden">{{ item.organisation.name }}</p>
               View on map (opens in new tab)
             </a>
             {% if item.categories|length %}

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -109,7 +109,7 @@
                 <span class="notranslate" translate="no">{{ item.location.postcode }}</span>
             </div>
             <a class="govuk-link govuk-!-display-none-print" class="url" target="_blank" rel="noopener" href="https://www.google.com/maps/search/?{{ item|google_map_params|urlencode }}">
-              <p class="govuk-visually-hidden">{{ item.organisation.name }}</p>
+              <span class="govuk-visually-hidden">{{ item.organisation.name }}</span>
               View on map (opens in new tab)
             </a>
             {% if item.categories|length %}


### PR DESCRIPTION
## What does this pull request do?

- add hidden text of org name, for the 'View on map (opens in new tab)' links.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
