### PR TITLE
EL-1902: Handle LAALAA 404s

### DIFF
--- a/fala/apps/adviser/forms.py
+++ b/fala/apps/adviser/forms.py
@@ -184,7 +184,6 @@ class AdviserSearchForm(AdviserRootForm):
                 )
                 if "error" in data:
                     self.add_error("postcode", (data["error"]))
-                    return {}
                 return data
             except laalaa.LaaLaaError:
                 self.add_error(

--- a/fala/apps/adviser/laa_laa_paginator.py
+++ b/fala/apps/adviser/laa_laa_paginator.py
@@ -1,3 +1,6 @@
+import math
+
+
 class LaaLaaPaginator(object):
     def __init__(self, count, page_size, window_size, current_page):
         self._window_size = window_size
@@ -5,7 +8,7 @@ class LaaLaaPaginator(object):
             self._current_page = 1
         else:
             self._current_page = current_page
-        self._very_last_page = count // page_size + 1
+        self._very_last_page = math.ceil(count / page_size)
 
     @property
     def page_range(self):

--- a/fala/apps/adviser/tests/test_fala_views_and_functions.py
+++ b/fala/apps/adviser/tests/test_fala_views_and_functions.py
@@ -248,3 +248,14 @@ class AccessibilityViewTest(SimpleTestCase):
     def test_shows_new_accessibility_statement(self):
         response = self.client.get(self.url)
         self.assertContains(response, "Accessibility statement for Find a legal advisor")
+
+
+class ErrorPageTest(SimpleTestCase):
+    client = Client()
+    url = reverse("search")
+
+    def test_raises_404_when_page_number_does_not_exist(
+        self,
+    ):
+        response = self.client.get(self.url, {"postcode": "SE11", "page": 500})
+        self.assertEqual(response.status_code, 404)

--- a/fala/apps/adviser/tests/test_other_regions_playwright.py
+++ b/fala/apps/adviser/tests/test_other_regions_playwright.py
@@ -4,7 +4,7 @@ from fala.playwright.setup import PlaywrightTestSetup
 
 class OtherRegionsTest(PlaywrightTestSetup):
     def test_jersey(self):
-        results_page = self.visit_results_page("JE1")
+        results_page = self.visit_results_page(postcode="JE1")
         expect(results_page.h1).to_have_text("The postcode JE1 is in Jersey")
         search_page = results_page.change_search()
         # We don't preserve Jersey postcodes search term, by design, as we don't want residents from Jersey to use our service
@@ -13,7 +13,7 @@ class OtherRegionsTest(PlaywrightTestSetup):
     def test_scotland_with_persistant_search_and_categories(self):
         checkboxes = ["Family mediation", "Clinical Negligence"]
 
-        results_page = self.visit_results_page("TD13", checkboxes)
+        results_page = self.visit_results_page(postcode="TD13", checkbox_labels=checkboxes)
         expect(results_page.item_from_text("Legal Aid in Scotland")).to_be_visible()
         search_page = results_page.change_search()
 

--- a/fala/apps/adviser/tests/test_pagination_playwright.py
+++ b/fala/apps/adviser/tests/test_pagination_playwright.py
@@ -7,7 +7,7 @@ class PaginationResults(PlaywrightTestSetup):
     def test_results_pagination(self):
         checkboxes = ["Crime"]
 
-        page = self.visit_results_page("M25 3JF", checkboxes)
+        page = self.visit_results_page(postcode="M25 3JF", checkbox_labels=checkboxes)
         expect(page.item_from_text("results in order of closeness to M25 3JF.")).to_be_visible()
         first_page_result_count = page.result_count.inner_text()
         expect(page.pagination_link_title).to_be_visible()

--- a/fala/apps/adviser/tests/test_results_page_journeys_playwright.py
+++ b/fala/apps/adviser/tests/test_results_page_journeys_playwright.py
@@ -4,7 +4,15 @@ from fala.playwright.setup import PlaywrightTestSetup
 
 class ResultPageEndToEndJourneys(PlaywrightTestSetup):
     def test_change_search(self):
-        results_page = self.visit_results_page("SE11")
+        results_page = self.visit_results_page(postcode="SE11")
         expect(results_page.change_search_grey_box).to_have_text("Postcode: SE11")
         search_page = results_page.change_search()
         expect(search_page.h1).to_have_text("Find a legal aid adviser or family mediator")
+
+    def test_pagination_does_not_appear_when_there_is_one_page(self):
+        results_page = self.visit_results_page(postcode="W1J5BF", organisation="charles")
+        expect(results_page.pagination_link_title).not_to_be_visible()
+
+    def test_pagination_does_appears_when_there_is_more_than_one_page(self):
+        results_page = self.visit_results_page(postcode="SE11")
+        expect(results_page.pagination_link_title).to_be_visible()

--- a/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
+++ b/fala/apps/adviser/tests/test_search_page_journeys_playwright.py
@@ -36,7 +36,7 @@ class SearchPageEndToEndJourneys(PlaywrightTestSetup):
         ]
         for postcode in test_cases:
             with self.subTest(postcode=postcode):
-                page = self.visit_results_page(postcode)
+                page = self.visit_results_page(postcode=postcode)
                 expect(page.h1).to_have_text("Search results")
                 expect(page.change_search_grey_box.nth(0)).to_have_text(f"Postcode: {postcode}")
                 expect(page.item_from_text("in order of closeness")).to_be_visible()

--- a/fala/apps/adviser/views.py
+++ b/fala/apps/adviser/views.py
@@ -4,7 +4,7 @@ import urllib
 from django.conf import settings
 from django.urls import resolve, reverse
 from django.views.generic import TemplateView, ListView
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 import os
 from django.views import View
 
@@ -123,69 +123,72 @@ class SearchView(CommonContextMixin, ListView):
             return self._data.get("results", None)
 
         def get_context_data(self):
-            pages = LaaLaaPaginator(self._data["count"], 10, 3, self._form.current_page)
-            current_page = pages.current_page()
-            params = {
-                "postcode": self._form.cleaned_data["postcode"],
-                "name": self._form.cleaned_data["name"],
-            }
-            categories = self._form.cleaned_data["categories"]
+            if "Invalid page" in self._data.get("error", []):
+                raise Http404("Page not found")
+            else:
+                pages = LaaLaaPaginator(self._data["count"], 10, 3, self._form.current_page)
+                current_page = pages.current_page()
+                params = {
+                    "postcode": self._form.cleaned_data["postcode"],
+                    "name": self._form.cleaned_data["name"],
+                }
+                categories = self._form.cleaned_data["categories"]
 
-            # create list of tuples which can be passed to urlencode for pagination links
-            category_tuples = [("categories", c) for c in categories]
+                # create list of tuples which can be passed to urlencode for pagination links
+                category_tuples = [("categories", c) for c in categories]
 
-            def item_for(page_num):
-                if len(categories) > 0:
-                    page_params = {"page": page_num}
-                    href = (
-                        "/search?"
-                        + urllib.parse.urlencode({**page_params, **params})
-                        + "&"
-                        + urllib.parse.urlencode(category_tuples)
-                    )
-                else:
-                    page_params = {"page": page_num}
-                    href = "/search?" + urllib.parse.urlencode({**page_params, **params})
+                def item_for(page_num):
+                    if len(categories) > 0:
+                        page_params = {"page": page_num}
+                        href = (
+                            "/search?"
+                            + urllib.parse.urlencode({**page_params, **params})
+                            + "&"
+                            + urllib.parse.urlencode(category_tuples)
+                        )
+                    else:
+                        page_params = {"page": page_num}
+                        href = "/search?" + urllib.parse.urlencode({**page_params, **params})
 
-                return {"number": page_num, "current": self._form.current_page == page_num, "href": href}
+                    return {"number": page_num, "current": self._form.current_page == page_num, "href": href}
 
-            pagination = {"items": [item_for(page_num) for page_num in pages.page_range]}
+                pagination = {"items": [item_for(page_num) for page_num in pages.page_range]}
 
-            if current_page.has_previous():
-                if len(categories) > 0:
-                    page_params = {"page": current_page.previous_page_number()}
-                    prev_link = (
-                        "/search?"
-                        + urllib.parse.urlencode({**page_params, **params})
-                        + "&"
-                        + urllib.parse.urlencode(category_tuples)
-                    )
-                else:
-                    page_params = {"page": current_page.previous_page_number()}
-                    prev_link = "/search?" + urllib.parse.urlencode({**page_params, **params})
-                pagination["previous"] = {"href": prev_link}
+                if current_page.has_previous():
+                    if len(categories) > 0:
+                        page_params = {"page": current_page.previous_page_number()}
+                        prev_link = (
+                            "/search?"
+                            + urllib.parse.urlencode({**page_params, **params})
+                            + "&"
+                            + urllib.parse.urlencode(category_tuples)
+                        )
+                    else:
+                        page_params = {"page": current_page.previous_page_number()}
+                        prev_link = "/search?" + urllib.parse.urlencode({**page_params, **params})
+                    pagination["previous"] = {"href": prev_link}
 
-            if current_page.has_next():
-                if len(categories) > 0:
-                    page_params = {"page": current_page.next_page_number()}
-                    href = (
-                        "/search?"
-                        + urllib.parse.urlencode({**page_params, **params})
-                        + "&"
-                        + urllib.parse.urlencode(category_tuples)
-                    )
-                else:
-                    page_params = {"page": current_page.next_page_number()}
-                    href = "/search?" + urllib.parse.urlencode({**page_params, **params})
-                pagination["next"] = {"href": href}
+                if current_page.has_next():
+                    if len(categories) > 0:
+                        page_params = {"page": current_page.next_page_number()}
+                        href = (
+                            "/search?"
+                            + urllib.parse.urlencode({**page_params, **params})
+                            + "&"
+                            + urllib.parse.urlencode(category_tuples)
+                        )
+                    else:
+                        page_params = {"page": current_page.next_page_number()}
+                        href = "/search?" + urllib.parse.urlencode({**page_params, **params})
+                    pagination["next"] = {"href": href}
 
-            return {
-                "form": self._form,
-                "data": self._data,
-                "params": params,
-                "FEATURE_FLAG_SURVEY_MONKEY": settings.FEATURE_FLAG_SURVEY_MONKEY,
-                "pagination": pagination,
-            }
+                return {
+                    "form": self._form,
+                    "data": self._data,
+                    "params": params,
+                    "FEATURE_FLAG_SURVEY_MONKEY": settings.FEATURE_FLAG_SURVEY_MONKEY,
+                    "pagination": pagination if len(pagination["items"]) > 1 else {},
+                }
 
     class OtherJurisdictionState(object):
         REGION_TO_LINK = {

--- a/fala/playwright/setup.py
+++ b/fala/playwright/setup.py
@@ -26,12 +26,18 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
         self.browser.close()
         super().tearDown()
 
-    def visit_results_page(self, postcode, checkbox_labels=None):
+    def visit_results_page(self, **kwargs):
+        postcode = kwargs.get("postcode")
+        organisation = kwargs.get("organisation", None)
+        checkbox_labels = kwargs.get("checkbox_labels", None)
+
         if checkbox_labels is None:
             checkbox_labels = []
         page = self.browser.new_page()
         page.goto(f"{self.live_server_url}")
         page.get_by_label("Postcode").fill(postcode)
+        if organisation:
+            page.get_by_label("Name of organisation you are looking for (optional)").fill(organisation)
         for label in checkbox_labels:
             page.get_by_label(label).check()
         page.get_by_role("button", name="Search").click()


### PR DESCRIPTION
## What does this pull request do?

This PR does two things:
* raises a 404 error page when a user tries to access a page in the pagination that does not exist (via manipulating the URL)
* fixes two pagination issues: one cosmetic issue where we were displaying '1' at the bottom of the page when there was only one page, and a bigger issue where we were generating an additional, unnecessary page at the end of the pagination that created a 404 in LAALAA and subsequently a 500 in FALA (now would be 'Page not found' and we wouldn't see an error).

I targeted only handling 404s differently as I don't know enough yet about other errors and the data structure that might come from LAALAA. Error handling is done quite weirdly, and the form is weirdly linked into the data response so haven't touched that. Most sensible place to raise 404 felt like the view given the current code structure.

Previously, 404s were being passed down to the forms/view weirdly, which meant the view was receiving no data structure - so everything blew up at the point of pagination. Have made the movement of data more sensible and now catching the 'Invalid page' with the 404.


## Any other changes that would benefit highlighting?

Needs some good UAT to make sure I haven't inadvertently broken how other errors are returned and to make sure pagination works as expected.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
