### PR TITLE
EL-1967 Add back link to single category search results

### DIFF
--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -8,6 +8,20 @@
   <div class="govuk-grid-column-full">
     <div id="google_translate_element" class="govuk-!-margin-bottom-6 govuk-!-display-none-print"></div>
   </div>
+  {% if tailored_results %}
+    <div class="govuk-grid-column-full">
+      <form action="/single-category-search" method="GET" novalidate>
+        {% for value, label_text in form.categories.field.choices %}
+          {% if label_text in form|category_selection_list %}
+            <input type="hidden" name="categories" value="{{ value }}">
+          {% endif %}
+        {% endfor %}
+        <a href="/single-category-search?{% for value, label_text in form.categories.field.choices %}{% if label_text in form|category_selection_list %}categories={{ value }}{% endif %}{% endfor %}" class="govuk-back-link govuk-!-margin-bottom-5 govuk-!-display-none-print">
+          Back
+        </a>
+      </form>
+    </div>
+  {% endif %}
   {% if FEATURE_FLAG_SURVEY_MONKEY %}
     {% include 'adviser/_research_banner.html' %}
   {% endif %}


### PR DESCRIPTION
## What does this pull request do?

Adds a back link that returns the user to the appropriate single category search page

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
