### PR TITLE
EL-2010: Remove staging deploy approval for FALA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,20 +221,9 @@ workflows:
             - laa-fala
             - laa-fala-live-staging
 
-      - staging_deploy_approval:
-          type: approval
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - main
-
       - deploy:
           name: Deploy to Staging
           environment: staging
-          requires:
-            - staging_deploy_approval
           filters:
             branches:
               only:
@@ -245,8 +234,6 @@ workflows:
 
       - deploy_grafana:
           name: Deploy Grafana Staging Dashboards
-          requires:
-            - staging_deploy_approval
           filters:
             branches:
               only:


### PR DESCRIPTION
## What does this pull request do?

Removes the staging deploy approval process for FALA staging env
Why? this was before we had multi env deployments so Staging had to be kept in a steady state,
We no longer require this step.
The production approval step can remain for the xmas period and afterwards we will comment it out as per CCQ

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
