### PR TITLE
BUGFIX: add requires for staging so deployment does not happen too soon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,8 @@ workflows:
       - deploy:
           name: Deploy to Staging
           environment: staging
+          requires:
+            - build
           filters:
             branches:
               only:


### PR DESCRIPTION
## What does this pull request do?

adds a requires to staging deployment so the image is built before we deploy

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
