### PR TITLE
El 2031 amend change search function

### DIFF
--- a/fala/apps/tests/page_objects.py
+++ b/fala/apps/tests/page_objects.py
@@ -55,7 +55,9 @@ class ResultsPage(FalaPage):
 
 
 class OtherRegionPage(FalaPage):
-    pass
+    @property
+    def back_link(self):
+        return self._page.locator(".govuk-back-link")
 
 
 class SearchPage(FalaPage):

--- a/fala/apps/tests/test_other_regions_playwright.py
+++ b/fala/apps/tests/test_other_regions_playwright.py
@@ -4,11 +4,11 @@ from fala.playwright.setup import PlaywrightTestSetup
 
 class OtherRegionsTest(PlaywrightTestSetup):
     def test_jersey(self):
-        results_page = self.visit_results_page(postcode="JE1")
-        expect(results_page.h1).to_have_text("The postcode JE1 is in Jersey")
-        search_page = results_page.change_search()
-        # We don't preserve Jersey postcodes search term, by design, as we don't want residents from Jersey to use our service
-        expect(search_page.item_from_text("Name of organisation you are looking for (optional)")).to_be_visible()
+        page = self.visit_results_page(postcode="JE1")
+        expect(page.h1).to_have_text("The postcode JE1 is in Jersey")
+        back_link = page.back_link
+        back_link.click()
+        expect(page.h1).to_have_text("Find a legal aid adviser or family mediator")
 
     def test_scotland_with_persistant_search_and_categories(self):
         checkboxes = ["Family mediation", "Clinical Negligence"]

--- a/fala/apps/tests/test_other_regions_playwright.py
+++ b/fala/apps/tests/test_other_regions_playwright.py
@@ -4,11 +4,18 @@ from fala.playwright.setup import PlaywrightTestSetup
 
 class OtherRegionsTest(PlaywrightTestSetup):
     def test_jersey(self):
-        page = self.visit_results_page(postcode="JE1")
-        expect(page.h1).to_have_text("The postcode JE1 is in Jersey")
+        results_page = self.visit_results_page(postcode="JE1")
+        expect(results_page.h1).to_have_text("The postcode JE1 is in Jersey")
+        search_page = results_page.change_search()
+        # We don't preserve Jersey postcodes search term, by design, as we don't want residents from Jersey to use our service
+        expect(search_page.item_from_text("Name of organisation you are looking for (optional)")).to_be_visible()
+
+    def test_iom(self):
+        page = self.visit_single_category_search_results_page("/immigration-or-asylum", "IM1 1AG")
+        expect(page.h1).to_have_text("The postcode IM1 1AG is in the Isle of Man")
         back_link = page.back_link
         back_link.click()
-        expect(page.h1).to_have_text("Find a legal aid adviser or family mediator")
+        expect(page.h1).to_have_text("Find a legal aid adviser for immigration or asylum")
 
     def test_scotland_with_persistant_search_and_categories(self):
         checkboxes = ["Family mediation", "Clinical Negligence"]

--- a/fala/apps/tests/test_other_regions_view.py
+++ b/fala/apps/tests/test_other_regions_view.py
@@ -47,18 +47,12 @@ class PostcodeValidationTest(SimpleTestCase):
                 response = self.client.get(self.url, data)
                 self.assertNotContains(response, case["message"])
 
-    def test_other_region_form_and_change_search_button_visible(self):
+    def test_back_link_is_visible(self):
         data = {"postcode": "IM4"}
         response = self.client.get(self.url, data)
         soup = bs4.BeautifulSoup(response.content, "html.parser")
-        form = soup.find("form", {"action": "/", "method": "get"})
-        button = soup.find("button", {"type": "submit", "data-module": "govuk-button"})
-        self.assertIsNotNone(form)
-        self.assertIsNotNone(button)
-
-        change_search_button = soup.find("button", {"id": "otherRegionChangeSearchButton"})
-        self.assertIsNotNone(change_search_button)
-        self.assertEqual(change_search_button.text.strip(), "Change search")
+        back_link = soup.find("a", class_="govuk-back-link")
+        self.assertIsNotNone(back_link, "Back button is not visible on the results page.")
 
 
 class InvalidPostcodeTest(SimpleTestCase):

--- a/fala/apps/tests/test_other_regions_view.py
+++ b/fala/apps/tests/test_other_regions_view.py
@@ -47,8 +47,21 @@ class PostcodeValidationTest(SimpleTestCase):
                 response = self.client.get(self.url, data)
                 self.assertNotContains(response, case["message"])
 
-    def test_back_link_is_visible(self):
+    def test_other_region_form_and_change_search_button_visible(self):
         data = {"postcode": "IM4"}
+        response = self.client.get(self.url, data)
+        soup = bs4.BeautifulSoup(response.content, "html.parser")
+        form = soup.find("form", {"action": "/", "method": "get"})
+        button = soup.find("button", {"type": "submit", "data-module": "govuk-button"})
+        self.assertIsNotNone(form)
+        self.assertIsNotNone(button)
+
+        change_search_button = soup.find("button", {"id": "otherRegionChangeSearchButton"})
+        self.assertIsNotNone(change_search_button)
+        self.assertEqual(change_search_button.text.strip(), "Change search")
+
+    def test_back_link_is_visible(self):
+        data = {"tailored_results": "true", "categories": "immas", "postcode": "IM4"}
         response = self.client.get(self.url, data)
         soup = bs4.BeautifulSoup(response.content, "html.parser")
         back_link = soup.find("a", class_="govuk-back-link")

--- a/fala/common/results_view.py
+++ b/fala/common/results_view.py
@@ -12,6 +12,7 @@ from fala.common.regions import Region
 class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesState, OtherJurisdictionState):
     def get(self, request, *args, **kwargs):
         self.tailored_results = self.request.GET.get("tailored_results", False)
+        self.category_code = self.request.GET.get("categories", False)
 
         if self.tailored_results:
             form_class = SingleCategorySearchForm
@@ -57,5 +58,6 @@ class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesSta
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["tailored_results"] = self.tailored_results
+        context["category_code"] = self.category_code
         context.update(self.state.get_context_data())
         return context

--- a/fala/locale/cy/LC_MESSAGES/django.po
+++ b/fala/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fala\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-23 15:14+0000\n"
+"POT-Creation-Date: 2025-01-27 12:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -572,33 +572,38 @@ msgid ""
 "device."
 msgstr ""
 
-#: fala/templates/adviser/other_region.html:8
+#: fala/templates/adviser/other_region.html:4
+#: fala/templates/adviser/results.html:26
+msgid "Back"
+msgstr ""
+
+#: fala/templates/adviser/other_region.html:5
+#: fala/templates/adviser/results.html:74
+msgid "Change search"
+msgstr ""
+
+#: fala/templates/adviser/other_region.html:15
 msgid "The postcode "
 msgstr ""
 
-#: fala/templates/adviser/other_region.html:8
+#: fala/templates/adviser/other_region.html:15
 msgid " is in "
 msgstr ""
 
-#: fala/templates/adviser/other_region.html:9
+#: fala/templates/adviser/other_region.html:16
 msgid "This search only covers England and Wales."
 msgstr ""
 
-#: fala/templates/adviser/other_region.html:11
+#: fala/templates/adviser/other_region.html:18
 msgid "Find out about "
 msgstr ""
 
-#: fala/templates/adviser/other_region.html:11
+#: fala/templates/adviser/other_region.html:18
 msgid "Legal Aid in "
 msgstr ""
 
-#: fala/templates/adviser/other_region.html:12
+#: fala/templates/adviser/other_region.html:19
 msgid "or try a different search."
-msgstr ""
-
-#: fala/templates/adviser/other_region.html:17
-#: fala/templates/adviser/results.html:74
-msgid "Change search"
 msgstr ""
 
 #: fala/templates/adviser/privacy.html:11
@@ -933,10 +938,6 @@ msgstr ""
 msgid "Last updated 25 June 2024"
 msgstr ""
 
-#: fala/templates/adviser/results.html:26
-msgid "Back"
-msgstr ""
-
 #: fala/templates/adviser/results.html:37
 msgid "No search results"
 msgstr ""
@@ -1097,6 +1098,6 @@ msgstr ""
 msgid "For example, SW1H 9AJ"
 msgstr ""
 
-#: fala/templates/base.html:7
+#: fala/templates/base.html:8
 msgid "GOV.UK - The best place to find government services and information"
 msgstr ""

--- a/fala/playwright/setup.py
+++ b/fala/playwright/setup.py
@@ -47,10 +47,7 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
         for label in checkbox_labels:
             page.get_by_label(label).check()
         page.get_by_role("button", name="Search").click()
-        if page.locator("#changeSearchButton").is_visible():
-            return ResultsPage(page)
-        else:
-            return OtherRegionPage(page)
+        return ResultsPage(page)
 
     def visit_results_page_with_full_search(self, postcode, organisation, checkbox_labels):
         page = self.browser.new_page()
@@ -60,10 +57,7 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
         for label in checkbox_labels:
             page.get_by_label(label).check()
         page.get_by_role("button", name="Search").click()
-        if page.locator("#changeSearchButton").is_visible():
-            return ResultsPage(page)
-        else:
-            return OtherRegionPage(page)
+        return ResultsPage(page)
 
     def visit_search_page_with_url_params(self, url_params):
         page = self.browser.new_page()
@@ -79,6 +73,16 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
         page = self.browser.new_page()
         page.goto(f"{self.live_server_url}/single-category-search{url_params}")
         return SingleCategorySearchPage(page)
+
+    def visit_single_category_search_results_page(self, url_params, postcode):
+        page = self.browser.new_page()
+        page.goto(f"{self.live_server_url}/single-category-search{url_params}")
+        page.get_by_label("Postcode").fill(postcode)
+        page.get_by_role("button", name="Search").click()
+        if page.locator("#changeSearchButton").is_visible():
+            return ResultsPage(page)
+        else:
+            return OtherRegionPage(page)
 
     def visit_cookies_page_from_footer(self):
         page = self.browser.new_page()

--- a/fala/playwright/setup.py
+++ b/fala/playwright/setup.py
@@ -47,7 +47,7 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
         for label in checkbox_labels:
             page.get_by_label(label).check()
         page.get_by_role("button", name="Search").click()
-        if page.locator("#changeSearchButton"):
+        if page.locator("#changeSearchButton").count() > 0:
             return ResultsPage(page)
         else:
             return OtherRegionPage(page)

--- a/fala/playwright/setup.py
+++ b/fala/playwright/setup.py
@@ -47,7 +47,7 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
         for label in checkbox_labels:
             page.get_by_label(label).check()
         page.get_by_role("button", name="Search").click()
-        if page.locator("#changeSearchButton").count() > 0:
+        if page.locator("#changeSearchButton").is_visible():
             return ResultsPage(page)
         else:
             return OtherRegionPage(page)
@@ -60,7 +60,7 @@ class PlaywrightTestSetup(StaticLiveServerTestCase):
         for label in checkbox_labels:
             page.get_by_label(label).check()
         page.get_by_role("button", name="Search").click()
-        if page.locator("#changeSearchButton"):
+        if page.locator("#changeSearchButton").is_visible():
             return ResultsPage(page)
         else:
             return OtherRegionPage(page)

--- a/fala/templates/adviser/other_region.html
+++ b/fala/templates/adviser/other_region.html
@@ -5,10 +5,12 @@
 {% block content %}
   <div class="govuk-grid-column-full">
     <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
-    {{ govukBackLink({
-      'text': "Back",
-      'href': url('adviser')
-    }) }}
+    {% if tailored_results %}
+      {{ govukBackLink({
+        'text': "Back",
+        'href': "/single-category-search?categories="+category_code,
+      }) }}
+    {% endif %}
     <h1 class="govuk-heading-xl">{{_('The postcode ')}}{{ postcode }}{{_(' is in ')}}{{ region }}</h1>
     <p class="govuk-body">{{_('This search only covers England and Wales.')}}</p>
     <p class="govuk-body">
@@ -16,11 +18,13 @@
       {{_('or try a different search.')}}
     </p>
 
-    <form action="/" method="get" novalidate>
-      <button type="submit" class="govuk-button govuk-!-margin-top-2" id="otherRegionChangeSearchButton" data-module="govuk-button">
-        {{_('Change search')}}
-      </button>
-    </form>
+    {% if not tailored_results %}
+      <form action="/" method="get" novalidate>
+        <button type="submit" class="govuk-button govuk-!-margin-top-2" id="otherRegionChangeSearchButton" data-module="govuk-button">
+          {{_('Change search')}}
+        </button>
+      </form>
+    {% endif %}
 
   </div>
 {% endblock %}

--- a/fala/templates/adviser/other_region.html
+++ b/fala/templates/adviser/other_region.html
@@ -20,9 +20,12 @@
 
     {% if not tailored_results %}
       <form action="/" method="get" novalidate>
-        <button type="submit" class="govuk-button govuk-!-margin-top-2" id="otherRegionChangeSearchButton" data-module="govuk-button">
-          {{_('Change search')}}
-        </button>
+        {{ govukButton({
+          'text': _('Change search'),
+          'type': "submit",
+          'classes': "govuk-!-margin-bottom-2",
+          'id': "otherRegionChangeSearchButton",
+        }) }}
       </form>
     {% endif %}
 

--- a/fala/templates/adviser/other_region.html
+++ b/fala/templates/adviser/other_region.html
@@ -5,6 +5,9 @@
 {% block content %}
   <div class="govuk-grid-column-full">
     <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+    <a href="{{ url('adviser') }}" class="govuk-back-link govuk-!-margin-bottom-5 govuk-!-display-none-print">
+      Back
+    </a>
     <h1 class="govuk-heading-xl">{{_('The postcode ')}}{{ postcode }}{{_(' is in ')}}{{ region }}</h1>
     <p class="govuk-body">{{_('This search only covers England and Wales.')}}</p>
     <p class="govuk-body">

--- a/fala/templates/adviser/other_region.html
+++ b/fala/templates/adviser/other_region.html
@@ -5,9 +5,10 @@
 {% block content %}
   <div class="govuk-grid-column-full">
     <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
-    <a href="{{ url('adviser') }}" class="govuk-back-link govuk-!-margin-bottom-5 govuk-!-display-none-print">
-      Back
-    </a>
+    {{ govukBackLink({
+      'text': "Back",
+      'href': url('adviser')
+    }) }}
     <h1 class="govuk-heading-xl">{{_('The postcode ')}}{{ postcode }}{{_(' is in ')}}{{ region }}</h1>
     <p class="govuk-body">{{_('This search only covers England and Wales.')}}</p>
     <p class="govuk-body">

--- a/fala/templates/adviser/other_region.html
+++ b/fala/templates/adviser/other_region.html
@@ -1,13 +1,14 @@
 {% extends 'adviser/adviser_base.html' %}
 
 {% block pageTitle %}{{_('Search results')}}{% endblock %}
-
+{% set BACK_LABEL = _("Back") %}
+{% set CHANGE_SEARCH = _("Change search") %}
 {% block content %}
   <div class="govuk-grid-column-full">
     <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
     {% if tailored_results %}
       {{ govukBackLink({
-        'text': "Back",
+        'text': BACK_LABEL,
         'href': "/single-category-search?categories="+category_code,
       }) }}
     {% endif %}
@@ -21,7 +22,7 @@
     {% if not tailored_results %}
       <form action="/" method="get" novalidate>
         {{ govukButton({
-          'text': _('Change search'),
+          'text': CHANGE_SEARCH,
           'type': "submit",
           'classes': "govuk-!-margin-bottom-2",
           'id': "otherRegionChangeSearchButton",

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -2,6 +2,7 @@
 
 {%- from 'govuk_frontend_jinja/components/cookie-banner/macro.html' import govukCookieBanner -%}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 
 <head>
   <title {%- if pageTitleLang %} lang="{{ pageTitleLang }}"{% endif %}>{% block pageTitle %}{{_('GOV.UK - The best place to find government services and information')}}{% endblock %}</title>


### PR DESCRIPTION
## What does this pull request do?

This pr removes the Change Search button, and adds a back link, to the other_region search results page.

It updates the tests to test for this. It also makes a small change to playwright setup, as I think the OtherRegionPage page_objects were not being loaded correctly.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
