### PR TITLE
el-1974: add language switcher link

### DIFF
--- a/fala/apps/tests/test_fala_views_and_functions.py
+++ b/fala/apps/tests/test_fala_views_and_functions.py
@@ -186,6 +186,27 @@ class ResearchBannerTest(SimpleTestCase):
         self.assertNotContains(response, self.research_message)
 
 
+class LanguageSwitcherTest(SimpleTestCase):
+    client = Client()
+    url = reverse("results")
+
+    data = {"name": "foo", "categories": ["deb", "edu"]}
+
+    @override_settings(FEATURE_FLAG_WELSH_TRANSLATION=True)
+    def test_language_switcher_visible_when_flag_set(self):
+        response = self.client.get(self.url, self.data)
+        soup = bs4.BeautifulSoup(response.content, features="html.parser")
+        language_switcher = soup.find("div", class_="language-switcher")
+        self.assertIsNotNone(language_switcher)
+
+    @override_settings(FEATURE_FLAG_WELSH_TRANSLATION=False)
+    def test_language_switcher_not_visible_when_flag_unset(self):
+        response = self.client.get(self.url, self.data)
+        soup = bs4.BeautifulSoup(response.content, features="html.parser")
+        language_switcher = soup.find("div", class_="language-switcher")
+        self.assertIsNone(language_switcher)
+
+
 class MaintenanceModeTest(SimpleTestCase):
     client = Client()
     url = reverse("results")

--- a/fala/assets-src/sass/main.scss
+++ b/fala/assets-src/sass/main.scss
@@ -25,8 +25,8 @@ body {
 
 .fala-tickbox-columns_new {
   // Default for mobile (1 column)
-  column-count: 1; 
-  // Adjust the gap between columns 
+  column-count: 1;
+  // Adjust the gap between columns
   column-gap: 16px;
 }
 
@@ -154,6 +154,10 @@ body.fala-dev {
   }
 }
 
+.language-switcher {
+  text-align: right;
+}
+
 .results-header {
   font-size: 19px;
   -webkit-font-smoothing: antialiased;
@@ -172,7 +176,7 @@ body.fala-dev {
   &:hover {
     background-color: govuk-colour("light-grey");
   }
-  
+
   &:focus {
     @include govuk-focused-text;
     background-color: $govuk-focus-colour;

--- a/fala/assets-src/sass/main.scss
+++ b/fala/assets-src/sass/main.scss
@@ -156,6 +156,7 @@ body.fala-dev {
 
 .language-switcher {
   text-align: right;
+  margin-right: govuk-spacing(0);
 }
 
 .results-header {

--- a/fala/common/mixin_for_views.py
+++ b/fala/common/mixin_for_views.py
@@ -15,6 +15,7 @@ class CommonContextMixin:
                 # this is added in so that an additional class is added the <body>
                 "bodyClasses": f"fala-{settings.ENVIRONMENT}",
                 "FEATURE_FLAG_MAINTENANCE_MODE": settings.FEATURE_FLAG_MAINTENANCE_MODE,
+                "FEATURE_FLAG_WELSH_TRANSLATION": settings.FEATURE_FLAG_WELSH_TRANSLATION,
             }
         )
         return context

--- a/fala/templates/adviser/_language_switcher.html
+++ b/fala/templates/adviser/_language_switcher.html
@@ -1,4 +1,4 @@
-<div class="govuk-grid-row language-switcher">
+<div class="govuk-grid-row govuk-!-display-none-print language-switcher">
   <p class="govuk-body">
     English / <a class="govuk-body govuk-link" href="/" target="_blank">Cymraeg</a>
   </p>

--- a/fala/templates/adviser/_language_switcher.html
+++ b/fala/templates/adviser/_language_switcher.html
@@ -1,0 +1,5 @@
+<div class="govuk-grid-row language-switcher">
+  <p class="govuk-body">
+    English / <a class="govuk-body govuk-link" href="/" target="_blank">Cymraeg</a>
+  </p>
+</div>

--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -44,6 +44,9 @@
   <div class="govuk-width-container">
     {% block global_subheader %}{% endblock %}
     <main id="main-content" class="govuk-main-wrapper" role="main">
+      {% if FEATURE_FLAG_WELSH_TRANSLATION %}
+        {% include 'adviser/_language_switcher.html' %}
+      {% endif %}
       <div class="govuk-grid-row">
         {% if FEATURE_FLAG_MAINTENANCE_MODE %}
           {% include 'maintenance_mode.html' %}


### PR DESCRIPTION
## What does this pull request do?

Adds a "language-switcher" link as per designs.

## Any other changes that would benefit highlighting?

Do we need to "save" when a user clicks on this link somewhere, or as a cookie?

I haven't added any functionality to change the link content when the user clicks it as I think this is part of the follow up ticket el-1975

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
