### PR TITLE
EL-2048: Make `Deploy Grafana Staging Dashboards` dependant on `build` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - build
           context:
             - laa-fala
             - laa-fala-live-staging


### PR DESCRIPTION
## What does this pull request do?

- make `Deploy Grafana Staging Dashboards` dependant on `build` job

## Any other changes that would benefit highlighting?

-n/a

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
