### PR TITLE
EL-2062: Remove empty space for city string, when there is no data

### DIFF
--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -128,7 +128,9 @@
             <div class="address">
               <span class="govuk-visually-hidden">{{ _('Address') }}:</span>
                 <span class="notranslate" translate="no">{{ item.location.address.replace('\n', ', ') }},</span>
-                <span class="notranslate" translate="no">{{ item.location.city }},</span>
+                {% if item.location.city %}
+                  <span class="notranslate" translate="no">{{ item.location.city }},</span>
+                {% endif%}
                 <span class="notranslate" translate="no">{{ item.location.postcode }}</span>
             </div>
             <a class="govuk-link govuk-!-display-none-print" class="url" target="_blank" rel="noopener" href="https://www.google.com/maps/search/?{{ item|google_map_params|urlencode }}">


### PR DESCRIPTION
## What does this pull request do?

- add condition, so that city string is only shown, when there is a city string.

## Any other changes that would benefit highlighting?

- n/a

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
