### PR TITLE
el-1976: hide google translate element when welsh feature flag enabled

### DIFF
--- a/fala/common/tests/playwright/test_translation_playwright.py
+++ b/fala/common/tests/playwright/test_translation_playwright.py
@@ -1,9 +1,11 @@
 from playwright.sync_api import expect
 from fala.common.test_utils.playwright.setup import PlaywrightTestSetup
+from django.test import override_settings
 
 
 class TranslationSelection(PlaywrightTestSetup):
 
+    @override_settings(FEATURE_FLAG_WELSH_TRANSLATION=False)
     def test_translate_to_welsh(self):
         page = self.visit_search_page()
         page.language_dropdown.select_option(label="Welsh")
@@ -15,13 +17,20 @@ class TranslationSelection(PlaywrightTestSetup):
         # this tests that the language selection persists when pagination buttons are clicked
         expect(page.h1).to_have_text("Canlyniadau chwilio")
 
+    @override_settings(FEATURE_FLAG_WELSH_TRANSLATION=False)
     def test_translate_to_irish(self):
         page = self.visit_search_page()
         # searching for the value of the dropdown, as 'Irish Gaelic' text, is not being found when running test on circleCi
         page.language_dropdown.select_option(value="ga")
         expect(page.h1).to_have_text("Aimsigh comhairleoir um chúnamh dlíthiúil nó idirghabhálaí teaghlaigh")
 
+    @override_settings(FEATURE_FLAG_WELSH_TRANSLATION=False)
     def test_translate_to_scots(self):
         page = self.visit_search_page()
         page.language_dropdown.select_option(label="Scots Gaelic")
         expect(page.h1).to_have_text("Lorg comhairliche taic laghail no eadar-mheadhanair teaghlaich")
+
+    @override_settings(FEATURE_FLAG_WELSH_TRANSLATION=True)
+    def with_welsh_translation_feature_flag_enabled(self):
+        page = self.visit_search_page()
+        expect(page.language_dropdown).not_to_be_visible()

--- a/fala/templates/adviser/accessibility_statement.html
+++ b/fala/templates/adviser/accessibility_statement.html
@@ -4,7 +4,9 @@
 
 {% block content %}
   <div class="govuk-grid-column-two-thirds">
-    <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+    {% if not FEATURE_FLAG_WELSH_TRANSLATION %}
+      <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+    {% endif %}
 
     <h1 class="govuk-heading-xl">{{_('Accessibility statement for Find a legal advisor')}}</h1>
 
@@ -44,12 +46,12 @@
       <li>{{_('Google Translate does not translate technical terms into Plain English')}}</li>
       <li>{{_('hyperlinks to google maps are not specific about the listing they are related to')}}</li>
     </ul>
-   
+
     <h2 class="govuk-heading-m">{{_('Feedback and contact information')}}</h2>
 
     <p class="govuk-body">
-      {{_('We’re always looking to improve the accessibility of this website. 
-      If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact us by email at')}} 
+      {{_('We’re always looking to improve the accessibility of this website.
+      If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact us by email at')}}
       <a class="govuk-link email" href="mailto:eligibility@justice.gov.uk">eligibility@justice.gov.uk</a>.
     </p>
 
@@ -85,11 +87,11 @@
     <p class="govuk-body">{{_('The content listed below is non-accessible for the following reasons.')}}</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>{{_('The results page border does not have sufficient colour contrast. 
+      <li>{{_('The results page border does not have sufficient colour contrast.
         This fails WCAG success criterion 1.4.3 Contrast (Minimum). We plan to fix this by the end of July 2024.')}}</li>
-      <li>{{_('The links to google maps elements are not identifiable from the link text alone. This fails WCAG success criterion 2.4.9 Link Purpose. 
+      <li>{{_('The links to google maps elements are not identifiable from the link text alone. This fails WCAG success criterion 2.4.9 Link Purpose.
         We plan to fix this by the end of October 2024.')}}</li>
-      <li>{{_('The results page title is the same as the main page and so does not clearly describe the topic or purpose. This fails WCAG success criterion 2.4.2 Page Titled. 
+      <li>{{_('The results page title is the same as the main page and so does not clearly describe the topic or purpose. This fails WCAG success criterion 2.4.2 Page Titled.
         We plan to fix this by the end of October 2024.')}}</li>
     </ul>
 
@@ -98,7 +100,7 @@
     <p class="govuk-body">{{_('Not applicable')}}</p>
 
     <h3 class="govuk-heading-s">{{_('Content that’s not within the scope of the accessibility regulations')}}</h3>
-   
+
     <p class="govuk-body">{{_('Not applicable')}}</p>
 
     <h2 class="govuk-heading-m">{{_('Preparation of this accessibility statement')}}</h2>
@@ -108,7 +110,7 @@
     </p>
 
     <p class="govuk-body">
-      {{_('This website was last tested on 12 June 2024. The test was carried out by the Ministry of Justice. 
+      {{_('This website was last tested on 12 June 2024. The test was carried out by the Ministry of Justice.
       We tested all of the pages using a basic accessibility test, but this was not a full audit.')}}
     </p>
 

--- a/fala/templates/adviser/category_search.html
+++ b/fala/templates/adviser/category_search.html
@@ -19,7 +19,9 @@
 {% block content %}
   <div class="govuk-grid-column-full">
     <span class="language-and-exit-container">
-      <div id="google_translate_element" class="govuk-!-margin-bottom-6 govuk-!-display-none-print"></div>
+      {% if not FEATURE_FLAG_WELSH_TRANSLATION %}
+        <div id="google_translate_element" class="govuk-!-margin-bottom-6 govuk-!-display-none-print"></div>
+      {% endif %}
       <div id="exit_button">
       {% if category_code == 'mat' %}
         {{ govukExitThisPage("Exit this page")}}

--- a/fala/templates/adviser/cookies.html
+++ b/fala/templates/adviser/cookies.html
@@ -15,7 +15,9 @@
 
 {% block content %}
   <div class="govuk-grid-column-full">
-    <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+    {% if not FEATURE_FLAG_WELSH_TRANSLATION %}
+      <div id="google_translate_element" class="govuk-!-margin-bottom-6">kat</div>
+    {% endif %}
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -101,7 +103,7 @@
         {{_('Google Analytics stores information about')}}
         {% include 'adviser/_analytics_and_privacy_list.html' %}
       </p>
-      
+
       <table class="govuk-table"><caption class="govuk-table__caption">{{_('Analytics cookies we use')}}</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">

--- a/fala/templates/adviser/other_region.html
+++ b/fala/templates/adviser/other_region.html
@@ -5,7 +5,9 @@
 {% set CHANGE_SEARCH = _("Change search") %}
 {% block content %}
   <div class="govuk-grid-column-full">
-    <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+    {% if not FEATURE_FLAG_WELSH_TRANSLATION %}
+      <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+    {% endif %}
     {% if tailored_results %}
       {{ govukBackLink({
         'text': BACK_LABEL,

--- a/fala/templates/adviser/privacy.html
+++ b/fala/templates/adviser/privacy.html
@@ -4,20 +4,22 @@
 
 {% block content %}
   <div class="govuk-grid-column-two-thirds">
-    <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+    {% if not FEATURE_FLAG_WELSH_TRANSLATION %}
+      <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+    {% endif %}
 
     <h1 class="govuk-heading-xl">{{_('Privacy')}}</h1>
 
     <h2 class="govuk-heading-m">{{_('What data we collect')}}</h2>
 
     <p class="govuk-body">
-      {{_('This service is provided by the')}} 
+      {{_('This service is provided by the')}}
       <a class="govuk-link" href="https://www.gov.uk/government/organisations/legal-aid-agency">{{_('Legal Aid Agency')}}</a> <abbr>(LAA)</abbr>,
       {{_('part of the Ministry of Justice')}} <abbr>(MoJ)</abbr>.
     </p>
 
     <p class="govuk-body">
-      {{_('We do not collect any')}} 
+      {{_('We do not collect any')}}
       <a class="govuk-link" href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/personal-information-what-is-it/what-is-personal-information-a-guide/">{{_('personal information')}}</a>
       {{_('that could identify an individual in this service.')}}
     </p>
@@ -71,10 +73,10 @@
     </p>
 
     <h2 class="govuk-heading-m">{{_('Our legal basis for processing your data')}}</h2>
-  
+
     <p class="govuk-body">
-      {{_('The legal basis for processing personal data in relation to site security is our legitimate interests, and the legitimate interests of our users, in ensuring the security and integrity of this service.')}} 
-      {{_('The legal basis for processing all other data is that it’s necessary to provide a service and our legitimate interest in understanding the usage of our service.')}} 
+      {{_('The legal basis for processing personal data in relation to site security is our legitimate interests, and the legitimate interests of our users, in ensuring the security and integrity of this service.')}}
+      {{_('The legal basis for processing all other data is that it’s necessary to provide a service and our legitimate interest in understanding the usage of our service.')}}
     </p>
 
     <p class="govuk-body">
@@ -120,7 +122,7 @@
     <h2 class="govuk-heading-m">{{_('How we protect your data and keep it secure')}}</h2>
 
     <p class="govuk-body">
-      {{_('We are committed to doing all that we can to keep your data secure.')}} 
+      {{_('We are committed to doing all that we can to keep your data secure.')}}
       {{_('We have set up systems and processes to prevent unauthorised access or disclosure of your data. ')}}
     </p>
 
@@ -175,7 +177,7 @@
 
     <p class="govuk-body">
       {{_('When we ask you for information, we will comply with the law. ')}}
-      {{_('If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection.')}} 
+      {{_('If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection.')}}
       {{_('You can contact the Information Commissioner at:')}}
     </p>
 

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -8,7 +8,9 @@
 {% block content %}
   <div class="govuk-grid-column-full">
     <span class="language-and-exit-container">
-      <div id="google_translate_element" class="govuk-!-margin-bottom-6 govuk-!-display-none-print"></div>
+      {% if not FEATURE_FLAG_WELSH_TRANSLATION %}
+        <div id="google_translate_element" class="govuk-!-margin-bottom-6 govuk-!-display-none-print"></div>
+        {% endif %}
       <div id="exit_button">
       {% if 'mat' in request.GET.getlist('categories') %}
         {{ govukExitThisPage("Exit this page")}}
@@ -165,7 +167,7 @@
           </li>
         {% endfor %}
       </ul>
-      <nav class="govuk-!-display-none-print"> 
+      <nav class="govuk-!-display-none-print">
         {{ govukPagination(pagination) }}
       </nav>
     {% endif %}

--- a/fala/templates/adviser/search.html
+++ b/fala/templates/adviser/search.html
@@ -11,7 +11,9 @@
 
 {% block content %}
   <div class="govuk-grid-column-two-thirds">
-      <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+      {% if not FEATURE_FLAG_WELSH_TRANSLATION %}
+        <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
+      {% endif %}
       {% if form.errors %}
         {{ govukErrorSummary({
           "titleText": _("There is a problem"),


### PR DESCRIPTION
## What does this pull request do?

Hide google translate functionality behind feature flag (if FEATURE_FLAG_WELSH_TRANSLATION enabled don't show google translate div)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
