### PR TITLE
EL-2006: Handle multiple categories in query param

### DIFF
--- a/fala/apps/adviser/templatetags/adviser_extras.py
+++ b/fala/apps/adviser/templatetags/adviser_extras.py
@@ -68,10 +68,11 @@ def category_selection(form):
 
 @library.filter
 def category_selection_first_item(form):
-    if "categories" in form.cleaned_data:
-        categories = [PROVIDER_CATEGORIES[cat] for cat in form.cleaned_data["categories"]]
-        if categories:
-            return categories[0]
+    categories = form.cleaned_data.get("categories", [])
+
+    if categories:
+        return PROVIDER_CATEGORIES.get(categories[0], None)
+
     return None
 
 

--- a/fala/apps/adviser/templatetags/adviser_extras.py
+++ b/fala/apps/adviser/templatetags/adviser_extras.py
@@ -67,6 +67,15 @@ def category_selection(form):
 
 
 @library.filter
+def category_selection_first_item(form):
+    if "categories" in form.cleaned_data:
+        categories = [PROVIDER_CATEGORIES[cat] for cat in form.cleaned_data["categories"]]
+        if categories:
+            return categories[0]
+    return None
+
+
+@library.filter
 def category_selection_list(form):
     if "categories" in form.cleaned_data:
         categories = [PROVIDER_CATEGORIES[cat] for cat in form.cleaned_data["categories"]]

--- a/fala/apps/category_search/forms.py
+++ b/fala/apps/category_search/forms.py
@@ -17,8 +17,8 @@ class CategorySearchForm(AdviserRootForm, BaseSearch):
         data = self.cleaned_data
         postcode = data.get("postcode")
 
-        if not postcode:
-            self.add_error("postcode", _("Enter a postcode"))
+        # this skips form validation if no postcode is in the request (e.g. during redirects)
+        if "postcode" not in self.data:
             return data
 
         if postcode:
@@ -27,6 +27,9 @@ class CategorySearchForm(AdviserRootForm, BaseSearch):
                 self.add_error("postcode", _("Enter a valid postcode"))
             else:
                 self._country_from_valid_postcode = valid_postcode
+        else:
+            self.add_error("postcode", _("Enter a postcode"))
+            return data
 
         return data
 

--- a/fala/apps/category_search/forms.py
+++ b/fala/apps/category_search/forms.py
@@ -5,7 +5,7 @@ from fala.common.utils import validate_postcode_and_return_country
 from fala.common.base_form_components import AdviserRootForm, BaseSearch
 
 
-class SingleCategorySearchForm(AdviserRootForm, BaseSearch):
+class CategorySearchForm(AdviserRootForm, BaseSearch):
     page = forms.IntegerField(required=False, widget=forms.HiddenInput())
 
     def __init__(self, categories=None, *args, **kwargs):
@@ -16,7 +16,6 @@ class SingleCategorySearchForm(AdviserRootForm, BaseSearch):
     def clean(self):
         data = self.cleaned_data
         postcode = data.get("postcode")
-        categories = self.data.get("categories")
 
         if not postcode:
             self.add_error("postcode", _("Enter a postcode"))
@@ -28,12 +27,6 @@ class SingleCategorySearchForm(AdviserRootForm, BaseSearch):
                 self.add_error("postcode", _("Enter a valid postcode"))
             else:
                 self._country_from_valid_postcode = valid_postcode
-
-        # Check if categories are provided
-        if not categories:
-            self.add_error("categories", _("Category is required."))
-        else:
-            self.categories = [categories]
 
         return data
 

--- a/fala/apps/category_search/forms.py
+++ b/fala/apps/category_search/forms.py
@@ -16,6 +16,7 @@ class CategorySearchForm(AdviserRootForm, BaseSearch):
     def clean(self):
         data = self.cleaned_data
         postcode = data.get("postcode")
+        self.categories = data.get("categories", [])
 
         # this skips form validation if no postcode is in the request (e.g. during redirects)
         if "postcode" not in self.data:

--- a/fala/apps/category_search/tests/test_search_view.py
+++ b/fala/apps/category_search/tests/test_search_view.py
@@ -34,14 +34,16 @@ class SearchViewTest(TestCase):
 
     def test_redirects_to_correct_category_url_with_multiple_categories(self):
         response = self.client.get(
-            reverse("category_search_query") + f"?categories={self.clinical_negligence_code},{self.welfare_benefits_code}"
+            reverse("category_search_query")
+            + f"?categories={self.clinical_negligence_code},{self.welfare_benefits_code}"
         )
         expected_url = f"{self.clinical_negligence_url}?categories={self.welfare_benefits_code}"
         self.assertRedirects(response, expected_url)
-    
+
     def test_does_not_redirect_to_secondary_category_url(self):
         response = self.client.get(
-            reverse("category_search_query") + f"?categories={self.clinical_negligence_code},{self.welfare_benefits_code}"
+            reverse("category_search_query")
+            + f"?categories={self.clinical_negligence_code},{self.welfare_benefits_code}"
         )
 
         # Ensure we are not redirected to the secondary category page

--- a/fala/apps/category_search/tests/test_search_view.py
+++ b/fala/apps/category_search/tests/test_search_view.py
@@ -35,15 +35,15 @@ class SearchViewTest(TestCase):
     def test_redirects_to_correct_category_url_with_multiple_categories(self):
         response = self.client.get(
             reverse("category_search_query")
-            + f"?categories={self.clinical_negligence_code},{self.welfare_benefits_code}"
+            + f"?categories={self.clinical_negligence_code}&sub-categories={self.welfare_benefits_code}"
         )
-        expected_url = f"{self.clinical_negligence_url}?categories={self.welfare_benefits_code}"
+        expected_url = f"{self.clinical_negligence_url}?sub-categories={self.welfare_benefits_code}"
         self.assertRedirects(response, expected_url)
 
     def test_does_not_redirect_to_secondary_category_url(self):
         response = self.client.get(
             reverse("category_search_query")
-            + f"?categories={self.clinical_negligence_code},{self.welfare_benefits_code}"
+            + f"?categories={self.clinical_negligence_code}&sub-categories={self.welfare_benefits_code}"
         )
 
         # Ensure we are not redirected to the secondary category page

--- a/fala/apps/category_search/tests/test_search_view.py
+++ b/fala/apps/category_search/tests/test_search_view.py
@@ -32,6 +32,22 @@ class SearchViewTest(TestCase):
         response = self.client.get(reverse("category_search_query") + "?categories=invalid")
         self.assertRedirects(response, reverse("adviser"))
 
+    def test_redirects_to_correct_category_url_with_multiple_categories(self):
+        response = self.client.get(
+            reverse("category_search_query") + f"?categories={self.clinical_negligence_code},{self.welfare_benefits_code}"
+        )
+        expected_url = f"{self.clinical_negligence_url}?categories={self.welfare_benefits_code}"
+        self.assertRedirects(response, expected_url)
+    
+    def test_does_not_redirect_to_secondary_category_url(self):
+        response = self.client.get(
+            reverse("category_search_query") + f"?categories={self.clinical_negligence_code},{self.welfare_benefits_code}"
+        )
+
+        # Ensure we are not redirected to the secondary category page
+        self.assertNotEqual(response.url, self.welfare_benefits_url)
+        self.assertNotIn(f"/{self.welfare_benefits_slug}", response.url)
+
     def test_displays_search_form_clinical_negligence(self):
         response = self.client.get(self.clinical_negligence_url)
         self.assertEqual(response.status_code, 200)

--- a/fala/apps/category_search/tests/test_search_view.py
+++ b/fala/apps/category_search/tests/test_search_view.py
@@ -35,15 +35,15 @@ class SearchViewTest(TestCase):
     def test_redirects_to_correct_category_url_with_multiple_categories(self):
         response = self.client.get(
             reverse("category_search_query")
-            + f"?categories={self.clinical_negligence_code}&sub-categories={self.welfare_benefits_code}"
+            + f"?categories={self.clinical_negligence_code}&sub-category={self.welfare_benefits_code}"
         )
-        expected_url = f"{self.clinical_negligence_url}?sub-categories={self.welfare_benefits_code}"
+        expected_url = f"{self.clinical_negligence_url}?sub-category={self.welfare_benefits_code}"
         self.assertRedirects(response, expected_url)
 
     def test_does_not_redirect_to_secondary_category_url(self):
         response = self.client.get(
             reverse("category_search_query")
-            + f"?categories={self.clinical_negligence_code}&sub-categories={self.welfare_benefits_code}"
+            + f"?categories={self.clinical_negligence_code}&sub-category={self.welfare_benefits_code}"
         )
 
         # Ensure we are not redirected to the secondary category page

--- a/fala/apps/category_search/views.py
+++ b/fala/apps/category_search/views.py
@@ -23,13 +23,16 @@ class CategorySearchView(CommonContextMixin, CategoryMixin, TemplateView):
             return result
 
         self.category_code = result[0]
-        self.secondary_category_code = result[1]
+        self.sub_category_code = result[1]
 
         category_message = CATEGORY_MESSAGES.get(self.category_slug, "")
         category_display_name = (self.category_slug or "").replace("-", " ").title()
 
         form = CategorySearchForm(
-            initial={"categories": [self.category_code, self.secondary_category_code]}, data=request.GET or None
+            initial={
+                "categories": [self.category_code] + ([self.sub_category_code] if self.sub_category_code else [])
+            },
+            data=request.GET or None,
         )
 
         search_url = reverse("results")
@@ -41,7 +44,7 @@ class CategorySearchView(CommonContextMixin, CategoryMixin, TemplateView):
                 "errorList": [],
                 "category_slug": self.category_slug,
                 "category_code": self.category_code,
-                "secondary_category_code": self.secondary_category_code,
+                "sub_category_code": self.sub_category_code,
                 "category_display_name": category_display_name,
                 "category_message": category_message,
                 "search_url": search_url,

--- a/fala/apps/category_search/views.py
+++ b/fala/apps/category_search/views.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.urls import reverse
 from django.views.generic import TemplateView
 from django.http import HttpResponse
-from category_search.forms import SingleCategorySearchForm
+from category_search.forms import CategorySearchForm
 from django.shortcuts import redirect
 from fala.common.mixin_for_views import CommonContextMixin, CategoryMixin
 from fala.common.category_messages import CATEGORY_MESSAGES
@@ -22,12 +22,15 @@ class CategorySearchView(CommonContextMixin, CategoryMixin, TemplateView):
         if isinstance(result, HttpResponse):
             return result
 
-        self.category_code = result
+        self.category_code = result[0]
+        self.secondary_category_code = result[1]
 
         category_message = CATEGORY_MESSAGES.get(self.category_slug, "")
-        category_display_name = self.category_slug.replace("-", " ").title()
+        category_display_name = (self.category_slug or "").replace("-", " ").title()
 
-        form = SingleCategorySearchForm(initial={"categories": [self.category_code]}, data=request.GET or None)
+        form = CategorySearchForm(
+            initial={"categories": [self.category_code, self.secondary_category_code]}, data=request.GET or None
+        )
 
         search_url = reverse("results")
 
@@ -38,6 +41,7 @@ class CategorySearchView(CommonContextMixin, CategoryMixin, TemplateView):
                 "errorList": [],
                 "category_slug": self.category_slug,
                 "category_code": self.category_code,
+                "secondary_category_code": self.secondary_category_code,
                 "category_display_name": category_display_name,
                 "category_message": category_message,
                 "search_url": search_url,

--- a/fala/common/mixin_for_views.py
+++ b/fala/common/mixin_for_views.py
@@ -25,7 +25,7 @@ class CommonContextMixin:
 class CategoryMixin:
     def setup_category(self, request, *args, **kwargs):
         category_code = request.GET.get("categories", "")
-        sub_category_code = request.GET.get("sub-categories", "")
+        sub_category_code = request.GET.get("sub-category", "")
 
         if not category_code:
             self.category_slug = kwargs.get("category")
@@ -39,7 +39,7 @@ class CategoryMixin:
             self.category_slug = CategoryManager.slug_from(category_code)
             if sub_category_code:
                 url = reverse("category_search", kwargs={"category": self.category_slug})
-                return redirect(f"{url}?sub-categories={sub_category_code}")
+                return redirect(f"{url}?sub-category={sub_category_code}")
             if self.category_slug:
                 return redirect("category_search", category=self.category_slug)
             else:

--- a/fala/common/mixin_for_views.py
+++ b/fala/common/mixin_for_views.py
@@ -23,20 +23,32 @@ class CommonContextMixin:
 
 class CategoryMixin:
     def setup_category(self, request, *args, **kwargs):
-        category_code = request.GET.get("categories")
+        category_code = request.GET.get("categories", "")
 
-        if not category_code:
+        # default variables
+        main_category_code = category_code
+        # TO-DO, hard coded for now
+        secondary_category_code = "immas"
+
+        # assign value to variable if there is a comma
+        if "," in category_code:
+            main_category_code = category_code.split(",")[0]
+            secondary_category_code = category_code.split(",")[1]
+
+        if not main_category_code:
             self.category_slug = kwargs.get("category")
             if not self.category_slug:  # Redirect if no category specified
                 return redirect("adviser")
             # if there is a slug, then retrieve the code based on the slug.
-            category_code = CategoryManager.category_code_from(self.category_slug)
-            if not category_code:
+            main_category_code = CategoryManager.category_code_from(self.category_slug)
+            if not main_category_code:
                 return redirect("adviser")
         else:
-            self.category_slug = CategoryManager.slug_from(category_code)
+            self.category_slug = CategoryManager.slug_from(main_category_code)
             if self.category_slug:
                 return redirect("category_search", category=self.category_slug)
             else:
                 return redirect("adviser")
-        return category_code
+
+        category_codes = [main_category_code, secondary_category_code]
+        return category_codes

--- a/fala/common/mixin_for_views.py
+++ b/fala/common/mixin_for_views.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from django.conf import settings
 from django.shortcuts import redirect
+from django.urls import reverse
 from fala.common.category_manager import CategoryManager
 
 
@@ -20,35 +21,32 @@ class CommonContextMixin:
         )
         return context
 
-
 class CategoryMixin:
     def setup_category(self, request, *args, **kwargs):
         category_code = request.GET.get("categories", "")
 
-        # default variables
-        main_category_code = category_code
-        # TO-DO, hard coded for now
-        secondary_category_code = "immas"
+        # Check if main category is in the URL (e.g., /check/family) i.e we have already redirected the user once
+        main_category_from_url = kwargs.get("category")
 
-        # assign value to variable if there is a comma
-        if "," in category_code:
-            main_category_code = category_code.split(",")[0]
-            secondary_category_code = category_code.split(",")[1]
+        category_list = [c.strip() for c in category_code.split(",") if c.strip()]
 
-        if not main_category_code:
-            self.category_slug = kwargs.get("category")
-            if not self.category_slug:  # Redirect if no category specified
-                return redirect("adviser")
-            # if there is a slug, then retrieve the code based on the slug.
-            main_category_code = CategoryManager.category_code_from(self.category_slug)
-            if not main_category_code:
-                return redirect("adviser")
+        if main_category_from_url:
+            main_category_code = CategoryManager.category_code_from(main_category_from_url)
+            self.category_slug = main_category_from_url
         else:
-            self.category_slug = CategoryManager.slug_from(main_category_code)
-            if self.category_slug:
-                return redirect("category_search", category=self.category_slug)
-            else:
-                return redirect("adviser")
+            main_category_code = category_list[0] if category_list else None
+            self.category_slug = CategoryManager.slug_from(main_category_code) if main_category_code else None
 
-        category_codes = [main_category_code, secondary_category_code]
-        return category_codes
+        main_category_code, secondary_category_code = (category_list + [None])[:2]
+
+        # This prrevents a redirect loop that forces the user onto the search page for the secondary category
+        if main_category_from_url == self.category_slug:
+            return [main_category_code, secondary_category_code]
+
+        redirect_url = reverse("category_search", kwargs={"category": self.category_slug})
+
+        if secondary_category_code:
+            redirect_url += f"?categories={secondary_category_code}"
+
+        return redirect(redirect_url)
+

--- a/fala/common/results_view.py
+++ b/fala/common/results_view.py
@@ -34,15 +34,34 @@ class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesSta
                 category_display_name = (self.category_slug or "").replace("-", " ").title()
                 category_message = CATEGORY_MESSAGES.get(self.category_slug, "")
 
-                # this is so we can use category_code & search_url, when conducting a search from CategorySearchErrorState view
-                category_code = self.request.GET.get("categories", "")
+                # this is so we can use category_code, sub_category_code & search_url, when conducting a search from CategorySearchErrorState view
+                category_code = (
+                    self.request.GET.getlist("categories")[0]
+                    if len(self.request.GET.getlist("categories")) > 0
+                    else ""
+                )
+                sub_category_code = (
+                    self.request.GET.getlist("categories")[1]
+                    if len(self.request.GET.getlist("categories")) > 1
+                    else ""
+                )
                 search_url = reverse("results")
 
                 # this is so that we can get correct hlpas display name onto CategorySearchErrorState view
-                category_slug = self.request.GET.get("categories")
+                category_slug = (
+                    self.request.GET.getlist("categories")[0]
+                    if len(self.request.GET.getlist("categories")) > 0
+                    else ""
+                )
 
                 self.state = CategorySearchErrorState(
-                    form, category_display_name, category_message, category_code, search_url, category_slug
+                    form,
+                    category_display_name,
+                    category_message,
+                    category_code,
+                    sub_category_code,
+                    search_url,
+                    category_slug,
                 )
             else:
                 self.state = ErrorState(form)

--- a/fala/common/results_view.py
+++ b/fala/common/results_view.py
@@ -13,7 +13,7 @@ class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesSta
     def get(self, request, *args, **kwargs):
         self.tailored_results = self.request.GET.get("tailored_results", False)
         categories = self.request.GET.getlist("categories", [])
-        self.category_code = categories[0] if len(categories) > 0 else ""
+        self.category_code = categories[0] if categories else ""
         self.sub_category_code = categories[1] if len(categories) > 1 else ""
 
         if self.tailored_results:
@@ -35,26 +35,14 @@ class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesSta
                 self.setup_category(request, *args, **kwargs)
                 category_display_name = (self.category_slug or "").replace("-", " ").title()
                 category_message = CATEGORY_MESSAGES.get(self.category_slug, "")
+                categories = self.request.GET.getlist("categories", [])
 
                 # this is so we can use category_code, sub_category_code & search_url, when conducting a search from CategorySearchErrorState view
-                category_code = (
-                    self.request.GET.getlist("categories")[0]
-                    if len(self.request.GET.getlist("categories")) > 0
-                    else ""
-                )
-
-                sub_category_code = (
-                    self.request.GET.getlist("categories")[1]
-                    if len(self.request.GET.getlist("categories")) > 1
-                    else ""
-                )
+                category_code = categories[0] if categories else ""
+                sub_category_code = categories[1] if len(categories) > 1 else ""
 
                 # this is so that we can get correct hlpas display name onto CategorySearchErrorState view
-                category_slug = (
-                    self.request.GET.getlist("categories")[0]
-                    if len(self.request.GET.getlist("categories")) > 0
-                    else ""
-                )
+                category_slug = categories[0] if categories else ""
 
                 search_url = reverse("results")
 

--- a/fala/common/results_view.py
+++ b/fala/common/results_view.py
@@ -2,8 +2,8 @@
 from django.urls import reverse
 from django.views.generic import ListView
 from fala.apps.adviser.forms import AdviserSearchForm
-from fala.apps.category_search.forms import SingleCategorySearchForm
-from fala.common.states import EnglandOrWalesState, OtherJurisdictionState, ErrorState, SingleSearchErrorState
+from fala.apps.category_search.forms import CategorySearchForm
+from fala.common.states import EnglandOrWalesState, OtherJurisdictionState, ErrorState, CategorySearchErrorState
 from fala.common.mixin_for_views import CommonContextMixin, CategoryMixin
 from fala.common.category_messages import CATEGORY_MESSAGES
 from fala.common.regions import Region
@@ -15,7 +15,7 @@ class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesSta
         self.category_code = self.request.GET.get("categories", False)
 
         if self.tailored_results:
-            form_class = SingleCategorySearchForm
+            form_class = CategorySearchForm
         else:
             form_class = AdviserSearchForm
 
@@ -29,19 +29,19 @@ class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesSta
                 self.state = OtherJurisdictionState(region, form.cleaned_data["postcode"])
         else:
             if self.tailored_results:
-                # using CategoryMixin to access category_display_name & category_message, so we show this on SingleSearchErrorState view
+                # using CategoryMixin to access category_display_name & category_message, so we show this on CategorySearchErrorState view
                 self.setup_category(request, *args, **kwargs)
-                category_display_name = self.category_slug.replace("-", " ").title()
+                category_display_name = (self.category_slug or "").replace("-", " ").title()
                 category_message = CATEGORY_MESSAGES.get(self.category_slug, "")
 
-                # this is so we can use category_code & search_url, when conducting a search from SingleSearchErrorState view
+                # this is so we can use category_code & search_url, when conducting a search from CategorySearchErrorState view
                 category_code = self.request.GET.get("categories", "")
                 search_url = reverse("results")
 
-                # this is so that we can get correct hlpas display name onto SingleSearchErrorState view
+                # this is so that we can get correct hlpas display name onto CategorySearchErrorState view
                 category_slug = self.request.GET.get("categories")
 
-                self.state = SingleSearchErrorState(
+                self.state = CategorySearchErrorState(
                     form, category_display_name, category_message, category_code, search_url, category_slug
                 )
             else:

--- a/fala/common/results_view.py
+++ b/fala/common/results_view.py
@@ -12,7 +12,9 @@ from fala.common.regions import Region
 class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesState, OtherJurisdictionState):
     def get(self, request, *args, **kwargs):
         self.tailored_results = self.request.GET.get("tailored_results", False)
-        self.category_code = self.request.GET.get("categories", False)
+        categories = self.request.GET.getlist("categories", [])
+        self.category_code = categories[0] if len(categories) > 0 else ""
+        self.sub_category_code = categories[1] if len(categories) > 1 else ""
 
         if self.tailored_results:
             form_class = CategorySearchForm
@@ -40,12 +42,12 @@ class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesSta
                     if len(self.request.GET.getlist("categories")) > 0
                     else ""
                 )
+
                 sub_category_code = (
                     self.request.GET.getlist("categories")[1]
                     if len(self.request.GET.getlist("categories")) > 1
                     else ""
                 )
-                search_url = reverse("results")
 
                 # this is so that we can get correct hlpas display name onto CategorySearchErrorState view
                 category_slug = (
@@ -53,6 +55,8 @@ class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesSta
                     if len(self.request.GET.getlist("categories")) > 0
                     else ""
                 )
+
+                search_url = reverse("results")
 
                 self.state = CategorySearchErrorState(
                     form,
@@ -78,5 +82,6 @@ class ResultsView(CommonContextMixin, CategoryMixin, ListView, EnglandOrWalesSta
         context = super().get_context_data(**kwargs)
         context["tailored_results"] = self.tailored_results
         context["category_code"] = self.category_code
+        context["sub_category_code"] = self.sub_category_code
         context.update(self.state.get_context_data())
         return context

--- a/fala/common/states.py
+++ b/fala/common/states.py
@@ -1,4 +1,5 @@
 from django.http import Http404
+from fala.common.category_manager import CategoryManager
 from fala.common.regions import Region
 from fala.common.laa_laa_paginator import LaaLaaPaginator
 import urllib
@@ -155,7 +156,7 @@ class ErrorState(object):
         }
 
 
-class SingleSearchErrorState(object):
+class CategorySearchErrorState(object):
     def __init__(self, form, category_display_name, category_message, category_code, search_url, category_slug):
         self._form = form
         self.category_display_name = category_display_name
@@ -181,7 +182,10 @@ class SingleSearchErrorState(object):
                 item = {"text": error[0], "href": f"#id_{field}"}
             errorList.append(item)
 
-        if self.category_slug == "hlpas":
+        # TO-DO need to get the first category code from URL not the second one
+        self.category_display_name = CategoryManager.slug_from(self.category_code).replace("-", " ").title()
+
+        if self.category_code == "hlpas":
             self.category_display_name = "Housing Loss Prevention Advice Service"
 
         return {

--- a/fala/common/states.py
+++ b/fala/common/states.py
@@ -1,5 +1,4 @@
 from django.http import Http404
-from fala.common.category_manager import CategoryManager
 from fala.common.regions import Region
 from fala.common.laa_laa_paginator import LaaLaaPaginator
 import urllib
@@ -157,11 +156,21 @@ class ErrorState(object):
 
 
 class CategorySearchErrorState(object):
-    def __init__(self, form, category_display_name, category_message, category_code, search_url, category_slug):
+    def __init__(
+        self,
+        form,
+        category_display_name,
+        category_message,
+        category_code,
+        sub_category_code,
+        search_url,
+        category_slug,
+    ):
         self._form = form
         self.category_display_name = category_display_name
         self.category_message = category_message
         self.category_code = category_code
+        self.sub_category_code = sub_category_code
         self.search_url = search_url
         self.category_slug = category_slug
 
@@ -182,10 +191,7 @@ class CategorySearchErrorState(object):
                 item = {"text": error[0], "href": f"#id_{field}"}
             errorList.append(item)
 
-        # TO-DO need to get the first category code from URL not the second one
-        self.category_display_name = CategoryManager.slug_from(self.category_code).replace("-", " ").title()
-
-        if self.category_code == "hlpas":
+        if self.category_slug == "hlpas":
             self.category_display_name = "Housing Loss Prevention Advice Service"
 
         return {
@@ -194,6 +200,7 @@ class CategorySearchErrorState(object):
             "errorList": errorList,
             "category_slug": self.category_slug,
             "category_code": self.category_code,
+            "sub_category_code": self.sub_category_code,
             "category_display_name": self.category_display_name,
             "category_message": self.category_message,
             "search_url": self.search_url,

--- a/fala/common/states.py
+++ b/fala/common/states.py
@@ -1,5 +1,6 @@
 from django.http import Http404
 from fala.common.category_manager import CategoryManager
+from fala.common.category_messages import CATEGORY_MESSAGES
 from fala.common.regions import Region
 from fala.common.laa_laa_paginator import LaaLaaPaginator
 import urllib
@@ -197,6 +198,8 @@ class CategorySearchErrorState(object):
 
         if self.category_code == "hlpas":
             self.category_display_name = "Housing Loss Prevention Advice Service"
+
+        self.category_message = CATEGORY_MESSAGES.get(CategoryManager.slug_from(self.category_code))
 
         return {
             "form": self._form,

--- a/fala/common/states.py
+++ b/fala/common/states.py
@@ -1,4 +1,5 @@
 from django.http import Http404
+from fala.common.category_manager import CategoryManager
 from fala.common.regions import Region
 from fala.common.laa_laa_paginator import LaaLaaPaginator
 import urllib
@@ -191,7 +192,9 @@ class CategorySearchErrorState(object):
                 item = {"text": error[0], "href": f"#id_{field}"}
             errorList.append(item)
 
-        if self.category_slug == "hlpas":
+        self.category_display_name = CategoryManager.slug_from(self.category_code).replace("-", " ").title()
+
+        if self.category_code == "hlpas":
             self.category_display_name = "Housing Loss Prevention Advice Service"
 
         return {

--- a/fala/templates/adviser/_results_heading.html
+++ b/fala/templates/adviser/_results_heading.html
@@ -1,11 +1,11 @@
 <div class="govuk-grid-column-two-thirds">
   {% if tailored_results %}
-      {% if form|category_selection|lower == "family" %}
+      {% if form|category_selection_first_item|lower == "family" %}
           <h1 class="govuk-heading-xl">{{_('Your closest legal aid advisers and family mediators')}}</h1>
-      {% elif form|category_selection|lower == "housing loss prevention advice service" %}
-          <h1 class="govuk-heading-xl">{{_('Your closest legal aid advisers for the ')}}{{ form|category_selection|title }}</h1>
+      {% elif form|category_selection_first_item|lower == "housing loss prevention advice service" %}
+          <h1 class="govuk-heading-xl">{{_('Your closest legal aid advisers for the ')}}{{ form|category_selection_first_item|title }}</h1>
       {% else %}
-          <h1 class="govuk-heading-xl">{{_('Your closest legal aid advisers for ')}}{{ form|category_selection|lower }}</h1>
+          <h1 class="govuk-heading-xl">{{_('Your closest legal aid advisers for ')}}{{ form|category_selection_first_item|lower }}</h1>
       {% endif %}
   {% else %}
       <h1 class="govuk-heading-xl">{{_('Search results')}}</h1>

--- a/fala/templates/adviser/category_search.html
+++ b/fala/templates/adviser/category_search.html
@@ -61,6 +61,9 @@
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ search_url }}" method="get" id="fala_questions_for_tailored_results">
         <input type="hidden" name="categories" value="{{ category_code }}">
+        {% if secondary_category_code %}
+          <input type="hidden" name="categories" value="{{ secondary_category_code }}">
+        {% endif %}
         <input type="hidden" name="tailored_results" value="true">
 
         {% set POSTCODE_CATEGORY_LABEL = _("What is your postcode?") %}

--- a/fala/templates/adviser/category_search.html
+++ b/fala/templates/adviser/category_search.html
@@ -26,7 +26,7 @@
     <span class="language-and-exit-container">
       <div id="google_translate_element" class="govuk-!-margin-bottom-6 govuk-!-display-none-print"></div>
       <div id="exit_button">
-      {% if category_code == 'mat' %}
+      {% if category_code == 'mat' or sub_category_code == 'mat' %}
         {{ govukExitThisPage("Exit this page")}}
       {% endif %}
     </div>

--- a/fala/templates/adviser/category_search.html
+++ b/fala/templates/adviser/category_search.html
@@ -61,8 +61,8 @@
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ search_url }}" method="get" id="fala_questions_for_tailored_results">
         <input type="hidden" name="categories" value="{{ category_code }}">
-        {% if secondary_category_code %}
-          <input type="hidden" name="categories" value="{{ secondary_category_code }}">
+        {% if sub_category_code %}
+          <input type="hidden" name="categories" value="{{ sub_category_code }}">
         {% endif %}
         <input type="hidden" name="tailored_results" value="true">
 

--- a/fala/templates/adviser/other_region.html
+++ b/fala/templates/adviser/other_region.html
@@ -7,11 +7,19 @@
   <div class="govuk-grid-column-full">
     <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
     {% if tailored_results %}
-      {{ govukBackLink({
-        'classes': "back_link_other_region",
-        'text': BACK_LABEL,
-        'href': "/check?categories="+category_code,
-      }) }}
+      {% if request.GET.getlist('categories')|length > 1 %}
+        {{ govukBackLink({
+          'classes': "back_link_other_region",
+          'text': BACK_LABEL,
+          'href': "/check?categories="+category_code+"&sub-categories="+sub_category_code,
+        }) }}
+      {% else %}
+        {{ govukBackLink({
+          'classes': "back_link_other_region",
+          'text': BACK_LABEL,
+          'href': "/check?categories="+category_code,
+        }) }}
+      {% endif %}
     {% endif %}
     <h1 class="govuk-heading-xl">{{_('The postcode ')}}{{ postcode }}{{_(' is in ')}}{{ region }}</h1>
     <p class="govuk-body">{{_('This search only covers England and Wales.')}}</p>

--- a/fala/templates/adviser/other_region.html
+++ b/fala/templates/adviser/other_region.html
@@ -11,13 +11,13 @@
     {% if tailored_results %}
       {% if request.GET.getlist('categories')|length > 1 %}
         {{ govukBackLink({
-          'classes': "back_link_other_region",
+          'classes': "back_link_other_region, govuk-!-margin-bottom-5",
           'text': BACK_LABEL,
-          'href': "/check?categories="+category_code+"&sub-categories="+sub_category_code,
+          'href': "/check?categories="+category_code+"&sub-category="+sub_category_code,
         }) }}
       {% else %}
         {{ govukBackLink({
-          'classes': "back_link_other_region",
+          'classes': "back_link_other_region, govuk-!-margin-bottom-5",
           'text': BACK_LABEL,
           'href': "/check?categories="+category_code,
         }) }}

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -19,10 +19,7 @@
   {% if tailored_results %}
     <div class="govuk-grid-column-full">
       <form action="/check" method="GET" novalidate>
-        {% for category in form.categories %}
-          <input type="hidden" name="categories" value="{{ category }}">
-        {% endfor %}
-        <a href="/check?categories={% for category in form.categories %}{{ category }}{% if not loop.last %},{% endif %}{% endfor %}" class="govuk-back-link govuk-!-margin-bottom-5 govuk-!-display-none-print" id="back_link">
+        <a href="/check?categories={{category_code}}" class="govuk-back-link govuk-!-margin-bottom-5 govuk-!-display-none-print" id="back_link">
           {{_('Back')}}
         </a>
       </form>

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -19,7 +19,7 @@
   {% if tailored_results %}
     <div class="govuk-grid-column-full">
       <form action="/check" method="GET" novalidate>
-        <a href="/check?categories={{category_code}}" class="govuk-back-link govuk-!-margin-bottom-5 govuk-!-display-none-print" id="back_link">
+        <a href="/check?categories={{category_code}}{% if sub_category_code %}&sub-categories={{ sub_category_code }}{% endif %}" class="govuk-back-link govuk-!-margin-bottom-5 govuk-!-display-none-print" id="back_link">
           {{_('Back')}}
         </a>
       </form>

--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -20,15 +20,23 @@
      </div>
     </span>
   </div>
-  {% if tailored_results %}
-    <div class="govuk-grid-column-full">
-      <form action="/check" method="GET" novalidate>
-        <a href="/check?categories={{category_code}}{% if sub_category_code %}&sub-categories={{ sub_category_code }}{% endif %}" class="govuk-back-link govuk-!-margin-bottom-5 govuk-!-display-none-print" id="back_link">
-          {{_('Back')}}
-        </a>
-      </form>
-    </div>
-  {% endif %}
+  <div class="govuk-grid-column-full">
+    {% if tailored_results %}
+      {% if request.GET.getlist('categories')|length > 1 %}
+        {{ govukBackLink({
+          'classes': "back_link, govuk-!-display-none-print, govuk-!-margin-bottom-5",
+          'text': BACK_LABEL,
+          'href': "/check?categories="+category_code+"&sub-category="+sub_category_code,
+        }) }}
+      {% else %}
+        {{ govukBackLink({
+          'classes': "back_link, govuk-!-display-none-print, govuk-!-margin-bottom-5",
+          'text': BACK_LABEL,
+          'href': "/check?categories="+category_code,
+        }) }}
+      {% endif %}
+    {% endif %}
+  </div>
 
   {% if FEATURE_FLAG_SURVEY_MONKEY %}
     {% include 'adviser/_research_banner.html' %}

--- a/fala/urls.py
+++ b/fala/urls.py
@@ -23,10 +23,6 @@ urlpatterns = [
     re_path(r"^search$", ResultsView.as_view(), name="results"),
     re_path(r"^robots\.txt$", RobotsTxtView.as_view(), name="robots_txt"),
     re_path(r"^security\.txt$", SecurityTxtView.as_view(), name="security_txt"),
-    re_path(
-        r"^check/(?P<category>[\w-]+)$",
-        CategorySearchView.as_view(),
-        name="category_search",
-    ),
+    re_path(r"^check/(?P<category>[\w-]+)$", CategorySearchView.as_view(), name="category_search"),
     re_path(r"^check$", CategorySearchView.as_view(), name="category_search_query"),
 ] + [re_path(r"^static/(?P<path>.*)$", serve, {"document_root": settings.STATIC_ROOT})]


### PR DESCRIPTION
## What does this pull request do?

- CLA will send over a URL which will look like:
   - `/check?categories=mat&sub-category=hlpas`
- FALA will now resolve this URL to:
  - `/check/family?sub-category=hlpas`
- form will not validate when there is a redirect 
- main category display name (and sub text) is shown on search form, results, & errors states
- handles single and multiple categories 
- back links work with multiple and single categories

## Any other changes that would benefit highlighting?

- n/a

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
