### PR TITLE
EL-2129: Remove redundant query param (`&search=`) from url

### DIFF
--- a/fala/templates/adviser/results.html
+++ b/fala/templates/adviser/results.html
@@ -87,8 +87,7 @@
             'text': changeSearchButton,
             'type': "submit",
             'classes': "govuk-!-margin-bottom-2 govuk-!-display-none-print",
-            'id': "changeSearchButton",
-            'name': "search"
+            'id': "changeSearchButton"
           }) }}
         </form>
       </div>

--- a/fala/templates/adviser/search.html
+++ b/fala/templates/adviser/search.html
@@ -147,8 +147,7 @@
                 'text': SEARCH_LABEL,
                 'type': "submit",
                 'classes': "govuk-!-margin-bottom-2",
-                'id': "searchButton",
-                'name': "search"
+                'id': "searchButton"
               }) }}
             </div>
           </form>


### PR DESCRIPTION
## What does this pull request do?

- if applied, the request URL will no longer include `&search=`

## Any other changes that would benefit highlighting?

- n/a

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
