### PR TITLE
EL-2071: Handle `govuk-frontend pagination component`, in order to get ‘previous’ & ‘next’ text translations

### DIFF
--- a/fala/common/states.py
+++ b/fala/common/states.py
@@ -68,7 +68,7 @@ class EnglandOrWalesState(object):
                 else:
                     page_params = {"page": current_page.previous_page_number()}
                     prev_link = "/search?" + urllib.parse.urlencode({**page_params, **params})
-                pagination["previous"] = {"href": prev_link}
+                pagination["previous"] = {"href": prev_link, "text": _("Previous")}
 
             if current_page.has_next():
                 if len(categories) > 0:
@@ -83,7 +83,7 @@ class EnglandOrWalesState(object):
                 else:
                     page_params = {"page": current_page.next_page_number()}
                     href = "/search?" + urllib.parse.urlencode({**page_params, **params})
-                pagination["next"] = {"href": href}
+                pagination["next"] = {"href": href, "text": _("Next")}
 
             return {
                 "form": self._form,

--- a/fala/locale/cy/LC_MESSAGES/django.po
+++ b/fala/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fala\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-21 14:18+0000\n"
+"POT-Creation-Date: 2025-02-27 15:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -92,6 +92,14 @@ msgstr ""
 "oes gennych blentyn sydd wedi cael anaf i’r ymennydd yn ystod beichiogrwydd, "
 "genedigaeth neu yn ystod 8 wythnos gyntaf ei fywyd."
 
+#: fala/common/states.py:71
+msgid "Previous"
+msgstr "Cynt"
+
+#: fala/common/states.py:86
+msgid "Next"
+msgstr "Nesaf"
+
 #: fala/common/states.py:101
 msgid "Northern Ireland"
 msgstr "Gogledd Iwerddon"
@@ -114,11 +122,11 @@ msgstr ""
 "Profwyd gwall wrth geisio dod o hyd i gynghorwyr cyfreithiol. Rhowch gynnig "
 "arall arni yn hwyrach ymlaen."
 
-#: fala/settings/base.py:66
+#: fala/settings/base.py:69
 msgid "English"
 msgstr "Saesneg"
 
-#: fala/settings/base.py:67
+#: fala/settings/base.py:70
 msgid "Cymraeg"
 msgstr "Cymraeg"
 


### PR DESCRIPTION
## What does this pull request do?

- if applied, this will add translation text for `previous` & `next` pagination links

## Any other changes that would benefit highlighting?

- n/a

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
