### PR TITLE
EL-2073: Update `Readme.md` about the use of babel Jinja2 component translations

### DIFF
--- a/docs/virtual-env.md
+++ b/docs/virtual-env.md
@@ -172,4 +172,11 @@ python manage.py compilemessages -l cy
 
 Django will use the `django.mo` file to display translations.
 
-**TODO** - The `makemessages` command in Django doesn't natively support Jinja2 templates. It is designed to work with Django's default template engine and expects translation strings to be in those templates.Still need to configure Django to handle Jinja2 templates during `makemessages` by adding the appropriate options and ensuring Jinja2 templates are included.
+### **To Note**
+
+The `makemessages` command in Django doesn’t understand the syntax of Jinja2 components and is designed to work with Django's default template engine. Therefore any strings in the Jinja2 components that need to be translated, have to be set as Jinja2 variables, within the templates. 
+
+There has been exploration in configuring this app to use `babel`, in order to translate the strings inside Jinja2 components, but the benefits in doing so did not outweigh the current implementation;
+- Django’s [documentation](https://docs.djangoproject.com/en/5.1/topics/i18n/translation/#localization-how-to-create-language-files) lacks clear instructions on integrating Babel.
+- Babel setup requires extra configuration (e.g., babel.cfg, manual extraction, compilation).
+- Using Django’s gettext system from views works well enough without the added complexity.


### PR DESCRIPTION
## What does this pull request do?

- If applied, this change will update the `readme.md` to capture decision on not using babel

## Any other changes that would benefit highlighting?

- n/a

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
