### PR TITLE
Remove debug text added in error

### DIFF
--- a/fala/templates/adviser/cookies.html
+++ b/fala/templates/adviser/cookies.html
@@ -16,7 +16,7 @@
 {% block content %}
   <div class="govuk-grid-column-full">
     {% if not FEATURE_FLAG_WELSH_TRANSLATION %}
-      <div id="google_translate_element" class="govuk-!-margin-bottom-6">kat</div>
+      <div id="google_translate_element" class="govuk-!-margin-bottom-6"></div>
     {% endif %}
 
     <div class="govuk-grid-row">


### PR DESCRIPTION
## What does this pull request do?

Remove debug text added in error as part of ticket to hide google translate functionality when  welsh translations enabled.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
