### PR TITLE
EL-2203: Indicate errors in page titles

### DIFF
--- a/fala/locale/cy/LC_MESSAGES/django.po
+++ b/fala/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fala\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-05 15:58+0000\n"
+"POT-Creation-Date: 2025-03-27 12:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1533,6 +1533,10 @@ msgstr "Gweld ar fap (mae’n agor mewn tab newydd)"
 #: fala/templates/adviser/results.html:146
 msgid "Can help with"
 msgstr "Yn gallu helpu gyda"
+
+#: fala/templates/adviser/search.html:3
+msgid "Error: "
+msgstr "Gwall: "
 
 #: fala/templates/adviser/search.html:3
 msgid "Find a Legal Aid Adviser or Family Mediator"

--- a/fala/templates/adviser/category_search.html
+++ b/fala/templates/adviser/category_search.html
@@ -1,15 +1,11 @@
 {% extends 'adviser/adviser_base.html' %}
 
 {% block pageTitle %}
-  {% if results %}
-    {{_('Search results')}}
+  {% if form.errors %}{{_('Error: ')}}{% endif %}{{_('Find a legal aid adviser for ')}}
+  {% if category_code == 'hlpas' %}
+    {{_('the')}} {{ _(category_display_name) | title }}
   {% else %}
-    {{_('Find a legal aid adviser for ')}}
-    {% if category_code == 'hlpas' %}
-      {{_('the')}} {{ _(category_display_name) | title }}
-    {% else %}
-      {{ _(category_display_name) | lower }}
-    {% endif %}
+    {{ _(category_display_name) | lower }}
   {% endif %}
 {% endblock %}
 

--- a/fala/templates/adviser/search.html
+++ b/fala/templates/adviser/search.html
@@ -1,6 +1,6 @@
 {% extends 'adviser/adviser_base.html' %}
 
-{% block pageTitle %}{{_('Find a Legal Aid Adviser or Family Mediator')}}{% endblock %}
+{% block pageTitle %}{% if form.errors %}{{_('Error: ')}}{% endif %}{{_('Find a Legal Aid Adviser or Family Mediator')}}{% endblock %}
 
 {% import "macros/element.html" as Element %}
 {% import "macros/forms.html" as Form %}


### PR DESCRIPTION
## What does this pull request do?

- If applied, this add 'Error: ' to the page title, when there is a form validation error.

## Any other changes that would benefit highlighting?

- [Uservision recommendation ](https://uv3202-moj-fala.uservisionaccessibility.co.uk/error-is-not-indicated-in-the-page-title-observation.html)

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
