### PR TITLE
EL-2295: Remove example text from secondary skip link

### DIFF
--- a/fala/templates/base.html
+++ b/fala/templates/base.html
@@ -33,7 +33,6 @@
   }) }}
 
   {% if category_code == 'mat' or sub_category_code == 'mat' %}
-    <p class="govuk-body">{{_('To view the secondary link, tab to or click inside this example and then press tab.')}}</p>
     {{ govukSkipLink({
       'text': exitText,
       'href': "https://bbc.co.uk/weather/",


### PR DESCRIPTION
## What does this pull request do?

-  Remove example text from secondary skip link

## Any other changes that would benefit highlighting?

- This is very confusing https://design-system.service.gov.uk/components/exit-this-page/

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
