### PR TITLE
remove manual release for CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,19 +246,8 @@ workflows:
             - laa-fala
             - laa-fala-live-staging
 
-      - production_deploy_approval:
-          type: approval
-          requires:
-            - Deploy to Staging
-          filters:
-            branches:
-              only:
-                - main
-
       - deploy_grafana:
           name: Deploy Grafana Production Dashboards
-          requires:
-            - production_deploy_approval
           filters:
             branches:
               only:
@@ -270,8 +259,6 @@ workflows:
       - deploy:
           name: Deploy to Production
           environment: production
-          requires:
-            - production_deploy_approval
           filters:
             branches:
               only:


### PR DESCRIPTION
## What does this pull request do?

removes need to manually approve deployments, so once a PR is merged we automatically deploy to production

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
