### PR TITLE
adding the sha pinning to the github actions

### DIFF
--- a/.github/workflows/helm-deploy.yml
+++ b/.github/workflows/helm-deploy.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 #v5.0.4
         with:
           path: ~/.cache/pip
           key: pip-lint-${{ hashFiles('requirements/generated/requirements-lint.txt') }}
@@ -50,13 +50,13 @@ jobs:
     needs: lint
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 #v5.0.4
         with:
           path: ~/.cache/pip
           key: pip-precommit-${{ hashFiles('requirements/generated/requirements-pre-commit.txt') }}
@@ -76,14 +76,14 @@ jobs:
     needs: [lint, pip-compile]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 #v5.0.4
         with:
           path: ~/.cache/pip
           key: pip-dev-${{ hashFiles('requirements/generated/requirements-dev.txt') }}
@@ -97,7 +97,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y --no-install-recommends gettext
           pip check
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -126,10 +126,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Set up AWS credentials for ECR and Kubernetes
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #6.1
         with:
           role-to-assume: ${{ secrets.FALA_ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.FALA_ECR_REGION }}
@@ -143,7 +143,7 @@ jobs:
           install: true
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 #v5.0.4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -174,7 +174,7 @@ jobs:
     environment: staging
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Deploy to staging with composite action
         uses: ./.github/actions/deploy
@@ -195,7 +195,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Deploy to staging with composite action
         uses: ./.github/actions/deploy

--- a/.github/workflows/helm-deploy.yml
+++ b/.github/workflows/helm-deploy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #6.2.0
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2593,10 +2593,12 @@
       "dev": true
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+      "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -4697,7 +4699,7 @@
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.18.0"
       }
     },
     "async-done": {
@@ -5287,7 +5289,7 @@
       "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.18.0"
       }
     },
     "eazy-logger": {
@@ -6242,9 +6244,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
       "dev": true
     },
     "lodash.clonedeep": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "homepage": "https://github.com/ministryofjustice/fala",
   "overrides": {
-    "lodash": "4.18.0",
+    "browser-sync": {
+      "lodash": "4.18.0"
+    },
     "minimatch": "^10.2.4",
     "resp-modifier": {
       "minimatch": "^10.2.4"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/ministryofjustice/fala",
   "overrides": {
-    "lodash": "4.18.21",
+    "lodash": "4.18.0",
     "minimatch": "^10.2.4",
     "resp-modifier": {
       "minimatch": "^10.2.4"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/ministryofjustice/fala",
   "overrides": {
+    "lodash": "^4.18.21",
     "minimatch": "^10.2.4",
     "resp-modifier": {
       "minimatch": "^10.2.4"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/ministryofjustice/fala",
   "overrides": {
-    "lodash": "^4.18.21",
+    "lodash": "4.18.21",
     "minimatch": "^10.2.4",
     "resp-modifier": {
       "minimatch": "^10.2.4"


### PR DESCRIPTION
## What does this pull request do?
Updated the existing GitHub Actions to use commit hashes instead of version tags. This makes sure each workflow runs against a fixed version, helping keep builds consistent and avoiding surprises from upstream changes.


Required.
checking hash matches the one reference to in github actions 
## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

[https://dsdmoj.atlassian.net/browse/LGA-3952](url)